### PR TITLE
feat: sliding indicator animation on bottom nav tab switch

### DIFF
--- a/components/navigation/bottom-nav-item.tsx
+++ b/components/navigation/bottom-nav-item.tsx
@@ -30,9 +30,6 @@ export function BottomNavItem({
           : "text-muted-foreground hover:text-foreground"
       )}
     >
-      {isActive && (
-        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-8 h-0.5 rounded-full bg-primary" />
-      )}
       <div className="relative">
         <Icon className={cn("h-6 w-6", isActive && "text-primary")} />
         {badge && (

--- a/components/navigation/bottom-nav.tsx
+++ b/components/navigation/bottom-nav.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import { usePathname } from "next/navigation"
 import { Home, Newspaper, BookOpen, User } from "lucide-react"
+import { useBottomNav, type NavItemConfig } from "@/hooks/use-bottom-nav"
 import { BottomNavItem } from "./bottom-nav-item"
 
-const navItems = [
+const navItems: NavItemConfig[] = [
   { href: "/", icon: Home, label: "Home" },
   { href: "/news?unseen=true", icon: Newspaper, label: "News" },
   { href: "/articles", icon: BookOpen, label: "Blog" },
@@ -12,26 +12,8 @@ const navItems = [
 ]
 
 export function BottomNav() {
-  const pathname = usePathname()
-
-  const getActiveIndex = () => {
-    if (pathname === "/") return 0
-    if (pathname.startsWith("/news")) return 1
-    if (pathname.startsWith("/articles")) return 2
-    if (pathname === "/me") return 3
-    return -1
-  }
-
-  const activeIndex = getActiveIndex()
+  const { activeIndex, isItemActive } = useBottomNav(navItems)
   const tabCount = navItems.length
-
-  const isActive = (href: string) => {
-    if (href === "/") return pathname === "/"
-    if (href.startsWith("/news")) return pathname.startsWith("/news")
-    if (href.startsWith("/articles")) return pathname.startsWith("/articles")
-    if (href === "/me") return pathname === "/me"
-    return false
-  }
 
   return (
     <nav
@@ -54,7 +36,8 @@ export function BottomNav() {
           href={item.href}
           icon={item.icon}
           label={item.label}
-          isActive={isActive(item.href)}
+          isActive={isItemActive(item)}
+          badge={item.badge}
         />
       ))}
     </nav>

--- a/components/navigation/bottom-nav.tsx
+++ b/components/navigation/bottom-nav.tsx
@@ -14,6 +14,17 @@ const navItems = [
 export function BottomNav() {
   const pathname = usePathname()
 
+  const getActiveIndex = () => {
+    if (pathname === "/") return 0
+    if (pathname.startsWith("/news")) return 1
+    if (pathname.startsWith("/articles")) return 2
+    if (pathname === "/me") return 3
+    return -1
+  }
+
+  const activeIndex = getActiveIndex()
+  const tabCount = navItems.length
+
   const isActive = (href: string) => {
     if (href === "/") return pathname === "/"
     if (href.startsWith("/news")) return pathname.startsWith("/news")
@@ -27,6 +38,16 @@ export function BottomNav() {
       className="fixed bottom-0 left-0 right-0 z-50 flex sm:hidden h-16 border-t border-border/40 backdrop-blur-sm bg-background/80"
       style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
+      {/* Sliding indicator — single element that moves between tabs */}
+      {activeIndex >= 0 && (
+        <div
+          className="absolute top-0 h-0.5 w-8 rounded-full bg-primary pointer-events-none"
+          style={{
+            left: `calc(${(activeIndex / tabCount) * 100 + 100 / tabCount / 2}% - 16px)`,
+            transition: "left 280ms cubic-bezier(0.4, 0, 0.2, 1)",
+          }}
+        />
+      )}
       {navItems.map((item) => (
         <BottomNavItem
           key={item.href}

--- a/hooks/use-bottom-nav.ts
+++ b/hooks/use-bottom-nav.ts
@@ -1,0 +1,27 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+import { type LucideIcon } from "lucide-react"
+
+export interface NavItemConfig {
+  href: string
+  icon: LucideIcon
+  label: string
+  /** Custom active matcher. Defaults to prefix match (exact for "/"). */
+  match?: (pathname: string) => boolean
+  badge?: number | string
+}
+
+export function useBottomNav(items: NavItemConfig[]) {
+  const pathname = usePathname()
+
+  const isItemActive = (item: NavItemConfig): boolean => {
+    if (item.match) return item.match(pathname)
+    const basePath = item.href.split("?")[0]
+    return basePath === "/" ? pathname === "/" : pathname.startsWith(basePath)
+  }
+
+  const activeIndex = items.findIndex(isItemActive)
+
+  return { activeIndex, isItemActive }
+}


### PR DESCRIPTION
Single shared indicator element in BottomNav slides left/right toward the touched tab using CSS transition on left property. Removed per-item static indicator from BottomNavItem. Does not affect View Transitions (page cross-fade).