### PR TITLE
feat(analytics): Cloudflare Web Analytics + granular GDPR consent

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -14,7 +14,7 @@ export default function PrivacyPage() {
       <main className="flex-1">
         <div className="container max-w-3xl mx-auto px-4 py-12 md:py-16 prose prose-invert prose-sm max-w-none">
           <h1>Privacy Policy</h1>
-          <p className="text-muted-foreground">Last updated: April 2026</p>
+          <p className="text-muted-foreground">Last updated: 26 April 2026</p>
 
           <h2>Who we are</h2>
           <p>
@@ -42,25 +42,36 @@ export default function PrivacyPage() {
 
           <h3>Analytics</h3>
           <p>
-            We use <strong>Vercel Analytics</strong> and <strong>Vercel Speed Insights</strong> to
-            understand how visitors use the site. These tools collect anonymized usage data
-            (page views, performance metrics). They are only loaded after you accept the cookie
-            consent banner. No personal data is collected by these tools.
+            We use <strong>Vercel Analytics</strong>, <strong>Vercel Speed Insights</strong>, and{' '}
+            <strong>Cloudflare Web Analytics</strong> to understand how visitors use the site.
+            These tools collect anonymized usage data (page views, performance metrics).
+            They are only loaded if you opt in to the &ldquo;Analytics&rdquo; category in the
+            cookie banner. No personal data is collected by these tools.
           </p>
 
-          <h3>Cookies</h3>
-          <p>We use the following cookies:</p>
+          <h3>Granular consent</h3>
+          <p>
+            The cookie banner gives you separate toggles for <strong>Analytics</strong> and{' '}
+            <strong>Advertising</strong>. You can accept one and reject the other.
+            Strictly necessary items (auth session and your consent state itself) are always on.
+            You can change your choice at any time via{' '}
+            <strong>Cookie settings</strong> in the footer.
+          </p>
+
+          <h3>Cookies and storage</h3>
+          <p>We use the following:</p>
           <ul>
-            <li><strong>gdpr-consent</strong> — Stores your cookie consent preference (accept/decline)</li>
-            <li><strong>visitedArticles</strong> — Tracks which articles you have read (for visual indicators)</li>
-            <li><strong>authjs.session-token</strong> — Authentication session (only if signed in)</li>
+            <li><strong>gdpr-consent</strong> — Stores your per-category consent preference (analytics, ads).</li>
+            <li><strong>visitedArticles</strong> — Tracks which articles you have read (for visual indicators).</li>
+            <li><strong>authjs.session-token</strong> — Authentication session (only if signed in).</li>
           </ul>
 
           <h3>Advertising</h3>
           <p>
             We may display ads from Google AdSense or other developer-focused ad networks
             on article and newsletter pages. These services may use cookies to serve relevant ads.
-            Ad scripts are only loaded after you accept the cookie consent banner.
+            Ad scripts are only loaded if you opt in to the &ldquo;Advertising&rdquo; category
+            in the cookie banner.
           </p>
 
           <h2>How we use your data</h2>

--- a/components/ad-slot.tsx
+++ b/components/ad-slot.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Script from 'next/script'
-import { useEffect, useState } from 'react'
+import { useConsent } from '@/lib/consent'
 
 interface AdSlotProps {
   format?: 'auto' | 'rectangle' | 'horizontal'
@@ -9,22 +9,9 @@ interface AdSlotProps {
 }
 
 export function AdSlot({ format = 'auto', className = '' }: AdSlotProps) {
-  const [hasConsent, setHasConsent] = useState(false)
+  const { ads } = useConsent()
 
-  useEffect(() => {
-    const consent = window.localStorage.getItem('gdpr-consent')
-    setHasConsent(consent === 'true')
-
-    const handleConsentChange = () => {
-      const updated = window.localStorage.getItem('gdpr-consent')
-      setHasConsent(updated === 'true')
-    }
-
-    window.addEventListener('gdpr-consent-changed', handleConsentChange)
-    return () => window.removeEventListener('gdpr-consent-changed', handleConsentChange)
-  }, [])
-
-  if (!hasConsent) return null
+  if (!ads) return null
 
   return (
     <aside className={`ad-slot ${className}`}>

--- a/components/adsense-script.tsx
+++ b/components/adsense-script.tsx
@@ -1,28 +1,20 @@
-'use client';
+'use client'
 
-import Script from 'next/script';
-import { useState } from 'react';
+import Script from 'next/script'
+import { useConsent } from '@/lib/consent'
 
 const AdsenseScript = () => {
-  const [consent] = useState(() => {
-    if (typeof window !== 'undefined' && window.localStorage) {
-      const storedConsent = window.localStorage.getItem('gdpr-consent');
-      return storedConsent === 'true';
-    }
-    return false;
-  });
+  const { ads } = useConsent()
 
-  if (!consent) {
-    return null;
-  }
+  if (!ads) return null
 
   return (
     <Script
       async
-      src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5937972178718571`}
+      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5937972178718571"
       crossOrigin="anonymous"
     />
-  );
-};
+  )
+}
 
-export default AdsenseScript;
+export default AdsenseScript

--- a/components/cloudflare-analytics.tsx
+++ b/components/cloudflare-analytics.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import Script from 'next/script'
+
+const TOKEN = process.env.NEXT_PUBLIC_CLOUDFLARE_ANALYTICS_TOKEN
+
+export function CloudflareAnalytics() {
+  if (!TOKEN) return null
+
+  return (
+    <Script
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon={JSON.stringify({ token: TOKEN })}
+      strategy="afterInteractive"
+      defer
+    />
+  )
+}

--- a/components/consent-gated-analytics.tsx
+++ b/components/consent-gated-analytics.tsx
@@ -1,31 +1,20 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
+import { CloudflareAnalytics } from '@/components/cloudflare-analytics'
+import { useConsent } from '@/lib/consent'
 
 export function ConsentGatedAnalytics() {
-  const [hasConsent, setHasConsent] = useState(false)
+  const { analytics } = useConsent()
 
-  useEffect(() => {
-    const consent = window.localStorage.getItem('gdpr-consent')
-    setHasConsent(consent === 'true')
-
-    const handleConsentChange = () => {
-      const updated = window.localStorage.getItem('gdpr-consent')
-      setHasConsent(updated === 'true')
-    }
-
-    window.addEventListener('gdpr-consent-changed', handleConsentChange)
-    return () => window.removeEventListener('gdpr-consent-changed', handleConsentChange)
-  }, [])
-
-  if (!hasConsent) return null
+  if (!analytics) return null
 
   return (
     <>
       <Analytics />
       <SpeedInsights />
+      <CloudflareAnalytics />
     </>
   )
 }

--- a/components/cookie-consent.tsx
+++ b/components/cookie-consent.tsx
@@ -48,7 +48,7 @@ const GdprConsent = () => {
     <div
       role="dialog"
       aria-label="Cookie consent"
-      className="fixed bottom-0 left-0 right-0 z-[1000] bg-[#1a1a1a] text-foreground border-t border-border/40 p-4 md:p-5"
+      className="dark fixed bottom-0 left-0 right-0 z-[1000] bg-[#1a1a1a] text-foreground border-t border-border/40 p-4 md:p-5"
     >
       <div className="container max-w-4xl mx-auto flex flex-col gap-3">
         {!showDetails ? (

--- a/components/cookie-consent.tsx
+++ b/components/cookie-consent.tsx
@@ -1,68 +1,150 @@
-'use client';
+'use client'
 
-import CookieConsent from 'react-cookie-consent';
-import { useState } from 'react';
+import { useEffect, useState } from 'react'
+import {
+  hasMadeChoice,
+  setConsent,
+  getConsent,
+  OPEN_SETTINGS_EVENT,
+} from '@/lib/consent'
 
 const GdprConsent = () => {
-  const [showBanner, setShowBanner] = useState(() => {
-    if (typeof window !== 'undefined' && window.localStorage) {
-      const consent = window.localStorage.getItem('gdpr-consent');
-      return !consent;
-    }
-    return true;
-  });
+  const [open, setOpen] = useState(false)
+  const [showDetails, setShowDetails] = useState(false)
+  const [analytics, setAnalytics] = useState(false)
+  const [ads, setAds] = useState(false)
 
-  const handleAccept = () => {
-    setShowBanner(false);
-    if (typeof window !== 'undefined' && window.localStorage) {
-      window.localStorage.setItem('gdpr-consent', 'true');
-      window.dispatchEvent(new Event('gdpr-consent-changed'));
+  useEffect(() => {
+    if (!hasMadeChoice()) {
+      setOpen(true)
     }
+    const reopen = () => {
+      const current = getConsent()
+      setAnalytics(current.analytics)
+      setAds(current.ads)
+      setShowDetails(true)
+      setOpen(true)
+    }
+    window.addEventListener(OPEN_SETTINGS_EVENT, reopen)
+    return () => window.removeEventListener(OPEN_SETTINGS_EVENT, reopen)
+  }, [])
+
+  if (!open) return null
+
+  const acceptAll = () => {
+    setConsent({ analytics: true, ads: true })
+    setOpen(false)
   }
-
-  const handleDecline = () => {
-    setShowBanner(false);
-    if (typeof window !== 'undefined' && window.localStorage) {
-      window.localStorage.setItem('gdpr-consent', 'false');
-      window.dispatchEvent(new Event('gdpr-consent-changed'));
-    }
+  const rejectAll = () => {
+    setConsent({ analytics: false, ads: false })
+    setOpen(false)
   }
-
-  if (!showBanner) {
-    return null;
+  const saveSelection = () => {
+    setConsent({ analytics, ads })
+    setOpen(false)
   }
 
   return (
-    <CookieConsent
-      location="bottom"
-      buttonText="Accept"
-      declineButtonText="Decline"
-      cookieName="gdpr-consent"
-      style={{ background: '#1a1a1a' }}
-      buttonStyle={{
-        background: 'var(--primary)',
-        color: 'var(--primary-foreground)',
-        fontSize: '13px',
-      }}
-      declineButtonStyle={{
-        background: 'var(--secondary)',
-        color: 'var(--secondary-foreground)',
-        fontSize: '13px',
-      }}
-      expires={150}
-      enableDeclineButton
-      onAccept={handleAccept}
-      onDecline={handleDecline}
+    <div
+      role="dialog"
+      aria-label="Cookie consent"
+      className="fixed bottom-0 left-0 right-0 z-[1000] bg-[#1a1a1a] text-foreground border-t border-border/40 p-4 md:p-5"
     >
-      <span>
-        We use cookies for analytics and advertising. See our{' '}
-        <a href="/privacy" style={{ color: 'var(--primary)', textDecoration: 'underline' }}>
-          privacy policy
-        </a>{' '}
-        for details.
-      </span>
-    </CookieConsent>
-  );
-};
+      <div className="container max-w-4xl mx-auto flex flex-col gap-3">
+        {!showDetails ? (
+          <>
+            <p className="text-sm text-muted-foreground">
+              We use cookies for analytics and advertising. You can choose which
+              ones to allow. See our{' '}
+              <a href="/privacy" className="text-primary underline">
+                privacy policy
+              </a>{' '}
+              for details.
+            </p>
+            <div className="flex flex-wrap gap-2 justify-end">
+              <button
+                onClick={() => setShowDetails(true)}
+                className="text-xs px-3 py-1.5 rounded bg-secondary text-secondary-foreground"
+              >
+                Customize
+              </button>
+              <button
+                onClick={rejectAll}
+                className="text-xs px-3 py-1.5 rounded bg-secondary text-secondary-foreground"
+              >
+                Reject all
+              </button>
+              <button
+                onClick={acceptAll}
+                className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground"
+              >
+                Accept all
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="space-y-2 text-sm">
+              <label className="flex items-start gap-3 cursor-not-allowed opacity-70">
+                <input type="checkbox" checked disabled className="mt-1" />
+                <span>
+                  <strong className="block">Strictly necessary</strong>
+                  <span className="text-muted-foreground text-xs">
+                    Required for the site to work (auth session, consent state).
+                    Always on.
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={analytics}
+                  onChange={(e) => setAnalytics(e.target.checked)}
+                  className="mt-1"
+                />
+                <span>
+                  <strong className="block">Analytics</strong>
+                  <span className="text-muted-foreground text-xs">
+                    Vercel Analytics, Vercel Speed Insights, Cloudflare Web
+                    Analytics. Anonymized usage and performance data.
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={ads}
+                  onChange={(e) => setAds(e.target.checked)}
+                  className="mt-1"
+                />
+                <span>
+                  <strong className="block">Advertising</strong>
+                  <span className="text-muted-foreground text-xs">
+                    Google AdSense. May set advertising cookies and share data
+                    with ad partners.
+                  </span>
+                </span>
+              </label>
+            </div>
+            <div className="flex flex-wrap gap-2 justify-end">
+              <button
+                onClick={rejectAll}
+                className="text-xs px-3 py-1.5 rounded bg-secondary text-secondary-foreground"
+              >
+                Reject all
+              </button>
+              <button
+                onClick={saveSelection}
+                className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground"
+              >
+                Save selection
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
 
-export default GdprConsent;
+export default GdprConsent

--- a/components/cookie-settings-link.tsx
+++ b/components/cookie-settings-link.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { openConsentSettings } from '@/lib/consent'
+
+export function CookieSettingsLink() {
+  return (
+    <button
+      type="button"
+      onClick={() => openConsentSettings()}
+      className="hover:text-primary transition-colors"
+    >
+      Cookie settings
+    </button>
+  )
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import { Code, Github, MailCheck } from "lucide-react"
+import { CookieSettingsLink } from "@/components/cookie-settings-link"
 
 export default function Footer() {
   return (
@@ -14,6 +15,8 @@ export default function Footer() {
 </p>
 <div className="flex items-center gap-3 text-xs text-muted-foreground">
   <Link href="/privacy" className="hover:text-primary transition-colors">Privacy</Link>
+  <span>·</span>
+  <CookieSettingsLink />
   <span>·</span>
   <Link href="/unsubscribe" className="hover:text-primary transition-colors">Unsubscribe</Link>
 </div>

--- a/docs/plans/2026-04-26-analytics-design.md
+++ b/docs/plans/2026-04-26-analytics-design.md
@@ -1,0 +1,76 @@
+# Analytics design — blog, newsletter, homepage
+
+> Captured: 2026-04-26
+
+## Goal
+
+Answer two questions:
+- **A. What content performs best?** — page views, top pages, referrers across `/`, `/news/[slug]`, `/articles/[slug]`, `/newsletter/[issue]`.
+- **B. Where do readers convert?** — newsletter signup funnel and CTA clicks.
+
+## Decision
+
+Start lean with **Cloudflare Web Analytics** (privacy-friendly, free, no cookies, no extra consent banner needed) layered on top of the existing `@vercel/analytics` + `@vercel/speed-insights`. Both are already gated behind GDPR consent in `components/consent-gated-analytics.tsx` — Cloudflare joins them.
+
+Defer custom events / Postgres `AnalyticsEvent` table until two weeks of pageview data tells us which conversion events are worth instrumenting. **YAGNI** for funnels until we know the questions we want to answer.
+
+## Why not GA4
+
+- GDPR overhead (extra banner, IP anonymization, EU lawyers still uncertain)
+- Data lives at Google — no joins with Prisma `Article`, `User`, `NewsletterSubscriber`
+- Free BigQuery export exists but adds a project to set up
+
+## Why not Postgres events first
+
+- Cloudflare cache is in front of motyl.dev — server-side request logging in middleware would undercount cached responses badly
+- Don't yet know which 5–10 events are worth a table; ship the cheap thing, learn, then add
+
+## Architecture
+
+```
+Browser
+  ├─ Cloudflare Beacon       ─┐
+  ├─ Vercel Analytics         ├─ gated on consent.analytics
+  └─ Vercel Speed Insights   ─┘
+  └─ Google AdSense (script + slots) ─ gated on consent.ads
+
+  Consent state in localStorage["gdpr-consent"]:
+    { analytics: bool, ads: bool, version: 1 }
+  Backwards-compatible read of legacy "true"/"false" string.
+```
+
+## Components
+
+- `lib/consent.ts` — single source of truth: `getConsent()`, `setConsent()`, `useConsent()`, `openConsentSettings()`. Migrates legacy `"true"|"false"` localStorage values to the new `{analytics, ads, version}` shape on read.
+- `components/cookie-consent.tsx` — banner with three actions (Accept all / Reject all / Customize). Customize reveals per-category checkboxes for Analytics and Advertising. Re-opens on `gdpr-consent-open` event.
+- `components/cookie-settings-link.tsx` — footer button that fires `openConsentSettings()` so users can revoke or change consent at any time.
+- `components/cloudflare-analytics.tsx` — injects `static.cloudflareinsights.com/beacon.min.js` with token from `NEXT_PUBLIC_CLOUDFLARE_ANALYTICS_TOKEN`. Renders nothing if env var is unset.
+- `components/consent-gated-analytics.tsx` — gates Vercel + Cloudflare on `consent.analytics`.
+- `components/adsense-script.tsx`, `components/ad-slot.tsx` — gate AdSense on `consent.ads`.
+- `app/privacy/page.tsx` — describes per-category toggles and the withdrawal path.
+
+## Data flow
+
+1. User loads any page → `RootLayout` mounts `<ConsentGatedAnalytics />`.
+2. If `gdpr-consent === "true"`, all three trackers mount; otherwise none of them load.
+3. Cloudflare beacon fires a single `POST` to `cloudflareinsights.com` with referrer + URL + UA. No cookies set.
+4. Cloudflare dashboard surfaces top pages, referrers, country breakdown.
+
+## Error handling
+
+- Missing token → component renders `null`; no script tag, no errors.
+- Script load failure → silent (Cloudflare beacon is non-critical, doesn't block render).
+
+## Testing
+
+- Manual: build + run dev, open with consent set to `true`, verify `beacon.min.js` request fires in DevTools Network with the configured token.
+- Manual: open with consent unset/false, verify no Cloudflare beacon request.
+- No unit tests — this is a 5-line script-tag wrapper; visual confirmation in DevTools is the test.
+
+## Future (not now)
+
+If after two weeks the Cloudflare dashboard can't answer a question we care about, add:
+- `prisma/schema.prisma` → `AnalyticsEvent { id, type, slug?, userId?, sessionId?, props Json, at }`
+- `app/api/track/route.ts` → POST endpoint, validates with zod
+- A handful of fire-and-forget `track()` calls at the meaningful points (newsletter signup confirmed, inline-CTA click, scroll-to-end on long articles)
+- `app/admin/analytics/page.tsx` — SQL-backed dashboard joining events with content

--- a/lib/consent.ts
+++ b/lib/consent.ts
@@ -1,0 +1,72 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export type ConsentState = {
+  analytics: boolean
+  ads: boolean
+  version: 1
+}
+
+const STORAGE_KEY = 'gdpr-consent'
+const CHANGE_EVENT = 'gdpr-consent-changed'
+export const OPEN_SETTINGS_EVENT = 'gdpr-consent-open'
+
+export const DEFAULT_CONSENT: ConsentState = {
+  analytics: false,
+  ads: false,
+  version: 1,
+}
+
+function readRaw(): ConsentState | null {
+  if (typeof window === 'undefined') return null
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (!raw) return null
+
+  if (raw === 'true') return { analytics: true, ads: true, version: 1 }
+  if (raw === 'false') return { analytics: false, ads: false, version: 1 }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<ConsentState>
+    return {
+      analytics: parsed.analytics === true,
+      ads: parsed.ads === true,
+      version: 1,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function getConsent(): ConsentState {
+  return readRaw() ?? DEFAULT_CONSENT
+}
+
+export function hasMadeChoice(): boolean {
+  return readRaw() !== null
+}
+
+export function setConsent(next: Omit<ConsentState, 'version'>): void {
+  if (typeof window === 'undefined') return
+  const value: ConsentState = { ...next, version: 1 }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value))
+  window.dispatchEvent(new Event(CHANGE_EVENT))
+}
+
+export function openConsentSettings(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new Event(OPEN_SETTINGS_EVENT))
+}
+
+export function useConsent(): ConsentState {
+  const [state, setState] = useState<ConsentState>(DEFAULT_CONSENT)
+
+  useEffect(() => {
+    setState(getConsent())
+    const handler = () => setState(getConsent())
+    window.addEventListener(CHANGE_EVENT, handler)
+    return () => window.removeEventListener(CHANGE_EVENT, handler)
+  }, [])
+
+  return state
+}


### PR DESCRIPTION
## Summary

- Adds **Cloudflare Web Analytics** behind the existing consent gate (free, cookieless, privacy-friendly) alongside Vercel Analytics + Speed Insights.
- Refactors consent into **per-purpose toggles** (Analytics, Advertising) — closes the GDPR gap of bundling AdSense with analytics under a single Accept.
- Adds a **withdrawal path**: footer "Cookie settings" link re-opens the banner so users can change or revoke consent at any time.

## Changes

**New**
- `lib/consent.ts` — single source of truth (`useConsent`, `setConsent`, `openConsentSettings`); migrates legacy `"true"/"false"` localStorage values to `{analytics, ads, version: 1}`.
- `components/cloudflare-analytics.tsx` — beacon component, no-op without `NEXT_PUBLIC_CLOUDFLARE_ANALYTICS_TOKEN`.
- `components/cookie-settings-link.tsx` — footer button that re-opens the banner.
- `docs/plans/2026-04-26-analytics-design.md` — design rationale + future Postgres-events extension.

**Refactored**
- `components/cookie-consent.tsx` — three actions (Accept all / Reject all / Customize) with per-category checkboxes; listens for `gdpr-consent-open` to re-open.
- `components/consent-gated-analytics.tsx` — gates Vercel + Cloudflare on `consent.analytics`.
- `components/adsense-script.tsx`, `components/ad-slot.tsx` — gate AdSense on `consent.ads`.
- `components/footer.tsx` — adds "Cookie settings" between Privacy and Unsubscribe.
- `app/privacy/page.tsx` — describes granular categories, mentions Cloudflare, points to footer; bumped to 26 April 2026.

## Configuration

Set in Vercel project env (production + preview):

```
NEXT_PUBLIC_CLOUDFLARE_ANALYTICS_TOKEN=<token from Cloudflare dashboard>
```

Without the token the beacon component renders `null` (safe in dev / preview / forks).

## GDPR posture (what this fixes vs. what it doesn't)

Fixes:
- ✅ Per-purpose consent (Analytics ≠ Advertising)
- ✅ Withdrawal mechanism
- ✅ Service disclosure inside the banner
- ✅ Equal-prominence Reject all on the first screen
- ✅ AdSense properly isolated for when it's approved

Out of scope:
- No script-tag rewriting / pre-consent blocking — relies on React conditional mounting (sufficient because all consumers gate on `useConsent`).
- No automatic cookie scanner; cookie list in `app/privacy/page.tsx` is maintained manually.
- No TCF-2.2 / IAB framework — only matters if programmatic ad networks beyond AdSense are added.

## Test plan

- [ ] Fresh visitor (incognito): banner shows; **Reject all** → no analytics or ad scripts load (verify in DevTools Network).
- [ ] **Accept all** → Vercel `_vercel/insights`, Cloudflare `cloudflareinsights.com/cdn-cgi/rum`, AdSense `pagead2.googlesyndication.com` all fire.
- [ ] **Customize** → Analytics on, Advertising off → only analytics requests fire; AdSense does not load.
- [ ] Footer **Cookie settings** re-opens the banner with current state preserved; saving updated selection takes effect immediately (event-driven).
- [ ] Legacy users with `gdpr-consent="true"` in localStorage: analytics + ads both treated as accepted (migration verified in `lib/consent.ts`).
- [ ] Legacy `"false"` value: both treated as rejected.
- [ ] `NEXT_PUBLIC_CLOUDFLARE_ANALYTICS_TOKEN` unset → no beacon request, no console errors.
- [ ] `/privacy` page renders the new "Granular consent" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)