### PR TITLE
feat(news): SuperAdmin-only news section

### DIFF
--- a/__tests__/pages/content-pages-header.test.tsx
+++ b/__tests__/pages/content-pages-header.test.tsx
@@ -2,9 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import Header from '@/components/header'
 
-// Mock next-auth/react
+// Mock next-auth/react with a controllable function
+const mockUseSession = vi.fn(() => ({ data: null, status: 'unauthenticated' }))
 vi.mock('next-auth/react', () => ({
-  useSession: () => ({ data: null, status: 'unauthenticated' }),
+  useSession: () => mockUseSession(),
+  signOut: vi.fn(),
 }))
 
 // Mock next/navigation
@@ -14,6 +16,7 @@ vi.mock('next/navigation', () => ({
 
 // Mock window.matchMedia for use-mobile hook
 beforeEach(() => {
+  mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' })
   vi.stubGlobal('BeforeInstallPromptEvent', undefined)
 
   Object.defineProperty(window, 'matchMedia', {
@@ -44,25 +47,42 @@ describe('Header component on content pages', () => {
     // Both desktop and mobile menus render the same links; use getAllByRole since
     // jsdom does not implement the inert attribute (which hides the mobile copies).
     expect(screen.getAllByRole('link', { name: 'About' })[0]).toBeInTheDocument()
-    expect(screen.getAllByRole('link', { name: 'News' })[0]).toBeInTheDocument()
     expect(screen.getAllByRole('link', { name: 'Blog' })[0]).toBeInTheDocument()
+    // News is superAdminOnly — must be absent for unauthenticated users
+    expect(screen.queryByRole('link', { name: 'News' })).toBeNull()
   })
 
   it('renders correct hrefs for navigation links', () => {
     render(<Header />)
 
     const aboutLink = screen.getAllByRole('link', { name: 'About' })[0]
-    const newsLink = screen.getAllByRole('link', { name: 'News' })[0]
     const blogLink = screen.getAllByRole('link', { name: 'Blog' })[0]
 
     expect(aboutLink).toHaveAttribute('href', '/about')
-    expect(newsLink).toHaveAttribute('href', '/news?unseen=true')
     expect(blogLink).toHaveAttribute('href', '/articles')
+    // News link is not rendered for unauthenticated users
   })
 
   it('shows "motyl.dev" text in header', () => {
     render(<Header />)
     expect(screen.getByText('motyl.dev')).toBeInTheDocument()
+  })
+
+  it('shows the News link with correct href for SuperAdmins', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          isSuperAdmin: true,
+          name: 'Admin',
+          email: 'admin@example.com',
+          image: null,
+        },
+      },
+      status: 'authenticated',
+    })
+    render(<Header />)
+    const newsLink = screen.getAllByRole('link', { name: 'News' })[0]
+    expect(newsLink).toHaveAttribute('href', '/news?unseen=true')
   })
 })
 

--- a/app/actions.test.ts
+++ b/app/actions.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/auth', () => ({
+  auth: vi.fn(async () => null),
+}))
+
+vi.mock('@/lib/articles', () => ({
+  getContentPageData: vi.fn(async () => ({
+    items: [],
+    totalItems: 0,
+    totalPages: 0,
+    currentPage: 1,
+    hashtagCounts: {},
+  })),
+}))
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(async () => new Map()),
+}))
+
+import { getFilteredContent } from './actions'
+import { auth } from '@/lib/auth'
+import { getContentPageData } from '@/lib/articles'
+
+describe('getFilteredContent — SuperAdmin gating', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('non-admin + contentType:all → getContentPageData called with contentType:article', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { isSuperAdmin: false } } as never)
+    await getFilteredContent({ contentType: 'all' })
+    expect(getContentPageData).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: 'article' })
+    )
+  })
+
+  it('unauthenticated + contentType:all → getContentPageData called with contentType:article', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    await getFilteredContent({ contentType: 'all' })
+    expect(getContentPageData).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: 'article' })
+    )
+  })
+
+  it('SuperAdmin + contentType:all → getContentPageData called with contentType:all', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { isSuperAdmin: true } } as never)
+    await getFilteredContent({ contentType: 'all' })
+    expect(getContentPageData).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: 'all' })
+    )
+  })
+
+  it('non-admin + contentType:article → getContentPageData called with contentType:article unchanged', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { isSuperAdmin: false } } as never)
+    await getFilteredContent({ contentType: 'article' })
+    expect(getContentPageData).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: 'article' })
+    )
+  })
+
+  it('non-admin + contentType:news → throws Forbidden, getContentPageData not called', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { isSuperAdmin: false } } as never)
+    await expect(getFilteredContent({ contentType: 'news' })).rejects.toThrow('Forbidden')
+    expect(getContentPageData).not.toHaveBeenCalled()
+  })
+
+  it('unauthenticated + contentType:news → throws Forbidden', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    await expect(getFilteredContent({ contentType: 'news' })).rejects.toThrow('Forbidden')
+    expect(getContentPageData).not.toHaveBeenCalled()
+  })
+
+  it('SuperAdmin + contentType:news → resolves, getContentPageData called', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { isSuperAdmin: true } } as never)
+    await expect(getFilteredContent({ contentType: 'news' })).resolves.toBeDefined()
+    expect(getContentPageData).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: 'news' })
+    )
+  })
+})

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -25,13 +25,18 @@ export async function getFilteredContent(filterState: FilterState) {
     excludeHashtags,
   } = filterState
 
+  // Fetch session once; used for both news rejection and 'all'→'article' downgrade.
+  const session = await auth()
+  const isSuperAdmin = !!session?.user?.isSuperAdmin
+
   // News is SuperAdmin-only; reject any non-SuperAdmin request for news content.
-  if (contentType === 'news') {
-    const session = await auth()
-    if (!session?.user?.isSuperAdmin) {
-      throw new Error('Forbidden')
-    }
+  if (contentType === 'news' && !isSuperAdmin) {
+    throw new Error('Forbidden')
   }
+
+  // Non-SuperAdmins requesting 'all' would receive news mixed in; downgrade to
+  // articles-only so pagination counts remain accurate and news never leaks.
+  const effectiveContentType = !isSuperAdmin && contentType === 'all' ? 'article' : contentType
 
   const headersList = await headers()
   const visitedArticlesHeader = headersList.get('x-visited-articles')
@@ -49,7 +54,7 @@ export async function getFilteredContent(filterState: FilterState) {
     page,
     filters,
     visitedSlugs,
-    contentType,
+    contentType: effectiveContentType,
   })
 
   return pageData

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -2,6 +2,7 @@
 
 import { getContentPageData, type PageFilters } from '@/lib/articles'
 import { headers } from 'next/headers'
+import { auth } from '@/lib/auth'
 
 interface FilterState {
   page?: number
@@ -23,6 +24,14 @@ export async function getFilteredContent(filterState: FilterState) {
     requireHashtags,
     excludeHashtags,
   } = filterState
+
+  // News is SuperAdmin-only; reject any non-SuperAdmin request for news content.
+  if (contentType === 'news') {
+    const session = await auth()
+    if (!session?.user?.isSuperAdmin) {
+      throw new Error('Forbidden')
+    }
+  }
 
   const headersList = await headers()
   const visitedArticlesHeader = headersList.get('x-visited-articles')

--- a/app/api/articles/[slug]/route.test.ts
+++ b/app/api/articles/[slug]/route.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ItemType } from '@/lib/types'
+
+vi.mock('@/lib/articles', () => ({
+  getAllContentMetadata: vi.fn(async () => [
+    { slug: 'my-article', title: 'My Article', itemType: ItemType.Article, hashtags: [], publishedAt: '2024-01-01', excerpt: '' },
+    { slug: 'breaking-news', title: 'Breaking News', itemType: ItemType.News, hashtags: [], publishedAt: '2024-01-02', excerpt: '' },
+  ]),
+  getContentItemBySlug: vi.fn(async () => null),
+}))
+
+import { generateStaticParams } from './route'
+import { getAllContentMetadata } from '@/lib/articles'
+
+describe('generateStaticParams — excludes news slugs', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('includes article slugs', async () => {
+    const params = await generateStaticParams()
+    expect(params.map((p) => p.slug)).toContain('my-article')
+  })
+
+  it('excludes news slugs', async () => {
+    const params = await generateStaticParams()
+    expect(params.map((p) => p.slug)).not.toContain('breaking-news')
+  })
+
+  it('returns only non-news items', async () => {
+    const params = await generateStaticParams()
+    expect(params).toHaveLength(1)
+    expect(params[0].slug).toBe('my-article')
+  })
+})

--- a/app/api/articles/[slug]/route.ts
+++ b/app/api/articles/[slug]/route.ts
@@ -1,16 +1,21 @@
 import { NextResponse } from 'next/server'
 import { getContentItemBySlug, getAllContentMetadata } from '@/lib/articles'
+import { ItemType } from '@/lib/types'
 
 // Force static generation at build time - no ISR revalidation
 export const dynamic = 'force-static'
 export const dynamicParams = false // Return 404 for unknown slugs
 
-// Generate static params for all articles at build time
+// Generate static params for non-news articles only. News is SuperAdmin-gated
+// and must not be pre-rendered as public static JSON. With dynamicParams=false,
+// any news slug returns 404 at runtime for all visitors.
 export async function generateStaticParams() {
   const articles = await getAllContentMetadata()
-  return articles.map((article) => ({
-    slug: article.slug,
-  }))
+  return articles
+    .filter((article) => article.itemType !== ItemType.News)
+    .map((article) => ({
+      slug: article.slug,
+    }))
 }
 
 export async function GET(request: Request, { params }: { params: Promise<{ slug: string }> }) {

--- a/app/api/content/route.test.ts
+++ b/app/api/content/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NextRequest } from 'next/server'
+import { auth } from '@/lib/auth'
 
 vi.mock('@/lib/articles', () => ({
   getContentPageData: vi.fn(async () => ({
@@ -47,5 +48,39 @@ describe('GET /api/content — limit query param', () => {
     expect(getContentPageData).toHaveBeenCalledWith(
       expect.objectContaining({ limit: 20 })
     )
+  })
+})
+
+describe('GET /api/content — news is SuperAdmin-only', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 403 for news when not authenticated', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const req = new NextRequest('http://localhost/api/content?contentType=news')
+    const res = await GET(req)
+    expect(res.status).toBe(403)
+    expect(getContentPageData).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 for news when logged-in but not SuperAdmin', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { isSuperAdmin: false } } as never)
+    const req = new NextRequest('http://localhost/api/content?contentType=news')
+    const res = await GET(req)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 200 for news when SuperAdmin', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { isSuperAdmin: true } } as never)
+    const req = new NextRequest('http://localhost/api/content?contentType=news')
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    expect(getContentPageData).toHaveBeenCalled()
+  })
+
+  it('stays public for articles when not authenticated', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const req = new NextRequest('http://localhost/api/content?contentType=article')
+    const res = await GET(req)
+    expect(res.status).toBe(200)
   })
 })

--- a/app/api/content/route.test.ts
+++ b/app/api/content/route.test.ts
@@ -84,3 +84,47 @@ describe('GET /api/content — news is SuperAdmin-only', () => {
     expect(res.status).toBe(200)
   })
 })
+
+describe('GET /api/content — all→article downgrade for non-SuperAdmins', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('non-admin + contentType=all → getContentPageData called with contentType:article', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { isSuperAdmin: false } } as never)
+    const req = new NextRequest('http://localhost/api/content?contentType=all')
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    expect(getContentPageData).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: 'article' })
+    )
+  })
+
+  it('unauthenticated + contentType=all → getContentPageData called with contentType:article', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const req = new NextRequest('http://localhost/api/content?contentType=all')
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    expect(getContentPageData).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: 'article' })
+    )
+  })
+
+  it('SuperAdmin + contentType=all → getContentPageData called with contentType:all', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { isSuperAdmin: true } } as never)
+    const req = new NextRequest('http://localhost/api/content?contentType=all')
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    expect(getContentPageData).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: 'all' })
+    )
+  })
+
+  it('default (no contentType param) non-admin → getContentPageData called with contentType:article', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const req = new NextRequest('http://localhost/api/content')
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    expect(getContentPageData).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: 'article' })
+    )
+  })
+})

--- a/app/api/content/route.ts
+++ b/app/api/content/route.ts
@@ -17,18 +17,23 @@ export async function GET(request: NextRequest) {
   const mode = searchParams.get('mode') as 'AND' | 'OR' | 'EXCLUDE' || 'AND'
   const includeContent = searchParams.get('includeContent') === 'true'
 
-  if (contentType === 'news') {
-    const session = await auth()
-    if (!session?.user?.isSuperAdmin) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
+  // Fetch session once; used for news rejection, 'all'→'article' downgrade, and
+  // unseen filtering. Avoids duplicate auth() calls.
+  const session = await auth()
+  const isSuperAdmin = !!session?.user?.isSuperAdmin
+
+  if (contentType === 'news' && !isSuperAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
+
+  // Non-SuperAdmins requesting 'all' would receive news mixed in; downgrade to
+  // articles-only so pagination counts remain accurate and news never leaks.
+  const effectiveContentType = !isSuperAdmin && contentType === 'all' ? 'article' : contentType
 
   let visitedSlugs = new Set<string>()
 
   if (showUnseen) {
     // Use DB for logged-in users so unseen filtering is consistent across devices
-    const session = await auth()
     if (session?.user?.id) {
       const dbSlugs = await getUserViewedArticles()
       visitedSlugs = new Set(dbSlugs)
@@ -59,7 +64,7 @@ export async function GET(request: NextRequest) {
       excludeHashtags,
     },
     visitedSlugs,
-    contentType,
+    contentType: effectiveContentType,
     includeContent,
   })
 

--- a/app/api/content/route.ts
+++ b/app/api/content/route.ts
@@ -17,6 +17,13 @@ export async function GET(request: NextRequest) {
   const mode = searchParams.get('mode') as 'AND' | 'OR' | 'EXCLUDE' || 'AND'
   const includeContent = searchParams.get('includeContent') === 'true'
 
+  if (contentType === 'news') {
+    const session = await auth()
+    if (!session?.user?.isSuperAdmin) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+  }
+
   let visitedSlugs = new Set<string>()
 
   if (showUnseen) {

--- a/app/api/trends/feed/route.test.ts
+++ b/app/api/trends/feed/route.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ItemType } from '@/lib/types'
+
+vi.mock('@/lib/trends', () => ({
+  getHomepageFeed: vi.fn(async () => ({
+    trendings: [],
+    lastWeekSummary: null,
+  })),
+}))
+
+vi.mock('@/lib/articles', () => ({
+  getAllContentMetadata: vi.fn(async () => [
+    { slug: 'article-1', title: 'Article 1', itemType: ItemType.Article, hashtags: [], publishedAt: '2024-01-03', excerpt: '' },
+    { slug: 'news-1', title: 'News 1', itemType: ItemType.News, hashtags: [], publishedAt: '2024-01-04', excerpt: '' },
+    { slug: 'article-2', title: 'Article 2', itemType: ItemType.Article, hashtags: [], publishedAt: '2024-01-02', excerpt: '' },
+    { slug: 'news-2', title: 'News 2', itemType: ItemType.News, hashtags: [], publishedAt: '2024-01-01', excerpt: '' },
+    { slug: 'article-3', title: 'Article 3', itemType: ItemType.Article, hashtags: [], publishedAt: '2024-01-05', excerpt: '' },
+    { slug: 'article-4', title: 'Article 4', itemType: ItemType.Article, hashtags: [], publishedAt: '2024-01-06', excerpt: '' },
+  ]),
+}))
+
+import { GET } from './route'
+
+describe('GET /api/trends/feed — news excluded from articles list', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 200', async () => {
+    const res = await GET()
+    expect(res.status).toBe(200)
+  })
+
+  it('articles list contains no news items', async () => {
+    const res = await GET()
+    const body = await res.json()
+    const newsItems = body.articles.filter((a: { itemType: string }) => a.itemType === ItemType.News)
+    expect(newsItems).toHaveLength(0)
+  })
+
+  it('articles list contains at most 5 items', async () => {
+    const res = await GET()
+    const body = await res.json()
+    expect(body.articles.length).toBeLessThanOrEqual(5)
+  })
+
+  it('articles list contains only article-type items', async () => {
+    const res = await GET()
+    const body = await res.json()
+    body.articles.forEach((a: { itemType: string }) => {
+      expect(a.itemType).toBe(ItemType.Article)
+    })
+  })
+})

--- a/app/api/trends/feed/route.ts
+++ b/app/api/trends/feed/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getHomepageFeed } from '@/lib/trends'
 import { getAllContentMetadata } from '@/lib/articles'
+import { ItemType } from '@/lib/types'
 
 export async function GET() {
   try {
@@ -9,7 +10,8 @@ export async function GET() {
       getAllContentMetadata(),
     ])
 
-    const latestArticles = articles.slice(0, 5)
+    // Exclude news from the public homepage feed; news is SuperAdmin-gated.
+    const latestArticles = articles.filter((a) => a.itemType !== ItemType.News).slice(0, 5)
 
     return NextResponse.json(
       {

--- a/app/news/[slug]/page.test.tsx
+++ b/app/news/[slug]/page.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/require-super-admin', () => ({
+  requireSuperAdmin: vi.fn(async () => undefined),
+}))
+
+vi.mock('@/lib/articles', () => ({
+  getContentItemBySlug: vi.fn(async () => null),
+  getAllContentMetadata: vi.fn(async () => []),
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => { throw new Error('NOT_FOUND') }),
+}))
+
+vi.mock('@/components/content-page', () => ({
+  default: vi.fn(() => null),
+}))
+
+import NewsItemPage from './page'
+import { requireSuperAdmin } from '@/lib/require-super-admin'
+import { getContentItemBySlug } from '@/lib/articles'
+
+describe('NewsItemPage — SuperAdmin guard', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('calls requireSuperAdmin with /news/<slug> before fetching content', async () => {
+    // Guard throws (simulates redirect for non-superadmin)
+    vi.mocked(requireSuperAdmin).mockRejectedValue(new Error('REDIRECT'))
+
+    await expect(
+      NewsItemPage({ params: Promise.resolve({ slug: 'test-slug' }) })
+    ).rejects.toThrow('REDIRECT')
+
+    expect(requireSuperAdmin).toHaveBeenCalledWith('/news/test-slug')
+    // Content must NOT have been fetched
+    expect(getContentItemBySlug).not.toHaveBeenCalled()
+  })
+
+  it('requireSuperAdmin is called before getContentItemBySlug', async () => {
+    const callOrder: string[] = []
+    vi.mocked(requireSuperAdmin).mockImplementation(async () => { callOrder.push('guard') })
+    vi.mocked(getContentItemBySlug).mockImplementation(async () => { callOrder.push('content'); return null })
+
+    // notFound throws, which is expected
+    await expect(
+      NewsItemPage({ params: Promise.resolve({ slug: 'my-slug' }) })
+    ).rejects.toThrow('NOT_FOUND')
+
+    expect(callOrder).toEqual(['guard', 'content'])
+  })
+})

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -69,30 +69,28 @@ export async function generateMetadata({ params: paramsPromise }: { params: Prom
 }
 
 export default async function NewsItemPage({ params: paramsPromise }: { params: Promise<{ slug: string }> }) {
-  try {
-    const params = await paramsPromise;
-    const { slug } = params
-    await requireSuperAdmin(`/news/${slug}`)
-    const article = await getContentItemBySlug(slug)
+  // No try/catch here: requireSuperAdmin (redirect) and notFound throw Next.js
+  // control-flow errors (NEXT_REDIRECT / NEXT_NOT_FOUND) that must propagate
+  // untouched — a generic catch would log them as false errors. Genuine errors
+  // surface through the route's error boundary.
+  const { slug } = await paramsPromise
+  await requireSuperAdmin(`/news/${slug}`)
+  const article = await getContentItemBySlug(slug)
 
-    if (!article) {
-      notFound()
-    }
-
-    // Get all article metadata for navigation
-    const allContent = await getAllContentMetadata()
-    const allNews = allContent.filter(item => item.itemType === ItemType.News);
-
-    // Find the current article's index
-    const currentIndex = allNews.findIndex((a) => a.slug === slug)
-
-    // Determine previous and next articles
-    const prevArticle = currentIndex > 0 ? allNews[currentIndex - 1] : null
-    const nextArticle = currentIndex < allNews.length - 1 ? allNews[currentIndex + 1] : null
-
-    return <ContentPage article={article} prevArticle={prevArticle} nextArticle={nextArticle} />
-  } catch (error) {
-    console.error('Error in NewsItemPage:', error)
-    throw error
+  if (!article) {
+    notFound()
   }
+
+  // Get all article metadata for navigation
+  const allContent = await getAllContentMetadata()
+  const allNews = allContent.filter(item => item.itemType === ItemType.News);
+
+  // Find the current article's index
+  const currentIndex = allNews.findIndex((a) => a.slug === slug)
+
+  // Determine previous and next articles
+  const prevArticle = currentIndex > 0 ? allNews[currentIndex - 1] : null
+  const nextArticle = currentIndex < allNews.length - 1 ? allNews[currentIndex + 1] : null
+
+  return <ContentPage article={article} prevArticle={prevArticle} nextArticle={nextArticle} />
 }

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -4,17 +4,7 @@ import ContentPage from '@/components/content-page'
 import { ItemType } from '@/lib/types'
 import { getContentUrl } from '@/lib/urls'
 import { getOgImage } from '@/lib/og'
-
-// Force static generation at build time
-export const dynamic = 'force-static'
-export const dynamicParams = false // Return 404 for unknown slugs (don't generate on-demand)
-
-export async function generateStaticParams() {
-  const articles = (await getAllContentMetadata()).filter(p => p.itemType === ItemType.News);
-  return articles.map((article) => ({
-    slug: article.slug,
-  }))
-}
+import { requireSuperAdmin } from '@/lib/require-super-admin'
 
 export async function generateMetadata({ params: paramsPromise }: { params: Promise<{ slug: string }> }) {
   try {
@@ -82,6 +72,7 @@ export default async function NewsItemPage({ params: paramsPromise }: { params: 
   try {
     const params = await paramsPromise;
     const { slug } = params
+    await requireSuperAdmin(`/news/${slug}`)
     const article = await getContentItemBySlug(slug)
 
     if (!article) {

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -3,6 +3,7 @@ import { ContentListing } from '@/components/content-listing'
 import { getAllHashtags } from '@/lib/articles'
 import Header from '@/components/header'
 import { readBatch, readManifest } from '@/lib/content-batches'
+import { requireSuperAdmin } from '@/lib/require-super-admin'
 
 export const revalidate = 300 // ISR: 5 min
 
@@ -16,6 +17,8 @@ export const metadata = {
 }
 
 export default async function NewsPage() {
+  await requireSuperAdmin('/news')
+
   const [initialBatch, manifest, allHashtags] = await Promise.all([
     readBatch('news', 0),
     readManifest(),

--- a/app/read-all-news/page.tsx
+++ b/app/read-all-news/page.tsx
@@ -3,6 +3,7 @@ import { headers } from 'next/headers'
 import { auth } from '@/lib/auth'
 import { getUserViewedArticles } from '@/lib/article-views'
 import ReadAllNewsPageClient from './page.client'
+import { requireSuperAdmin } from '@/lib/require-super-admin'
 
 export const metadata = {
   title: 'Read All News - Motyl.dev',
@@ -10,6 +11,8 @@ export const metadata = {
 }
 
 export default async function ReadAllNewsPage() {
+  await requireSuperAdmin('/read-all-news')
+
   const session = await auth()
   let visitedSlugs: Set<string>
 

--- a/app/sitemap.test.ts
+++ b/app/sitemap.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ItemType } from '@/lib/types'
+
+vi.mock('@/lib/articles', () => ({
+  getAllContentMetadata: vi.fn(async () => []),
+}))
+
+vi.mock('@/lib/urls', () => ({
+  getContentUrl: vi.fn((item: { slug: string; itemType: string }, absolute: boolean) => {
+    const base = absolute ? 'https://motyl.dev' : ''
+    const prefix = item.itemType === 'news' ? '/news' : '/articles'
+    return `${base}${prefix}/${item.slug}`
+  }),
+}))
+
+import sitemap from './sitemap'
+import { getAllContentMetadata } from '@/lib/articles'
+
+const mockNews = { slug: 'secret-news', itemType: ItemType.News, publishedAt: '2024-01-01', title: '', excerpt: '', hashtags: [], content: '' }
+const mockArticle = { slug: 'public-article', itemType: ItemType.Article, publishedAt: '2024-01-01', title: '', excerpt: '', hashtags: [], content: '' }
+
+describe('sitemap — news items excluded', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('includes article URLs but no news URLs', async () => {
+    vi.mocked(getAllContentMetadata).mockResolvedValue([mockNews, mockArticle] as never)
+
+    const result = await sitemap()
+    const urls = result.map((e) => e.url)
+
+    expect(urls.some((u) => u.includes('/articles/public-article'))).toBe(true)
+    expect(urls.some((u) => u.includes('/news/'))).toBe(false)
+  })
+
+  it('does not contain a static /news entry', async () => {
+    vi.mocked(getAllContentMetadata).mockResolvedValue([])
+
+    const result = await sitemap()
+    const urls = result.map((e) => e.url)
+
+    expect(urls.some((u) => u.endsWith('/news'))).toBe(false)
+  })
+})

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,13 +1,14 @@
 import { MetadataRoute } from 'next';
 import { getAllContentMetadata } from '@/lib/articles';
 import { getContentUrl } from '@/lib/urls';
+import { ItemType } from '@/lib/types';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = process.env.BASE_URL || 'https://motyl.dev';
 
   const content = await getAllContentMetadata();
 
-  const contentEntries: MetadataRoute.Sitemap = content.map((item) => {
+  const contentEntries: MetadataRoute.Sitemap = content.filter((item) => item.itemType !== ItemType.News).map((item) => {
     let lastModified: Date;
     try {
       lastModified = new Date(item.publishedAt);
@@ -32,12 +33,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: new Date(),
       changeFrequency: 'daily',
       priority: 1,
-    },
-    {
-      url: `${baseUrl}/news`,
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 0.9,
     },
     {
       url: `${baseUrl}/articles`,

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -11,19 +11,13 @@ import { SignInButton } from '@/components/sign-in-button'
 import { DevSignInButton } from '@/components/dev-sign-in-button'
 import { InstallPrompt } from '@/components/install-prompt'
 import { cn } from '@/lib/utils'
+import { getVisibleNavLinks } from '@/lib/nav-links'
 
 const SUPPORT_URL = 'https://www.buymeacoffee.com/motyl.dev'
 
-const NAV_LINKS = [
-  { label: 'Home', href: '/' },
-  { label: 'Newsletter', href: '/newsletter' },
-  { label: 'Blog', href: '/articles' },
-  { label: 'News', href: '/news?unseen=true' },
-  { label: 'About', href: '/about' },
-] as const
-
 export default function Header() {
   const { data: session, status } = useSession()
+  const navLinks = getVisibleNavLinks(!!session?.user?.isSuperAdmin)
   const pathname = usePathname()
   const [mobileOpen, setMobileOpen] = React.useState(false)
 
@@ -56,7 +50,7 @@ export default function Header() {
           className="ml-8 hidden lg:flex items-center gap-1"
           aria-label="Main navigation"
         >
-          {NAV_LINKS.map(({ label, href }) => (
+          {navLinks.map(({ label, href }) => (
             <Link
               key={href}
               href={href}
@@ -137,7 +131,7 @@ export default function Header() {
             className="flex flex-col gap-1 px-4 py-3"
             aria-label="Mobile navigation"
           >
-            {NAV_LINKS.map(({ label, href }) => (
+            {navLinks.map(({ label, href }) => (
               <Link
                 key={href}
                 href={href}

--- a/lib/nav-links.test.ts
+++ b/lib/nav-links.test.ts
@@ -4,12 +4,12 @@ import { getVisibleNavLinks } from './nav-links'
 describe('getVisibleNavLinks', () => {
   it('hides the News link for non-SuperAdmins', () => {
     const links = getVisibleNavLinks(false)
-    expect(links.some(l => l.href.startsWith('/news'))).toBe(false)
+    expect(links.some(l => l.label === 'News')).toBe(false)
     expect(links.some(l => l.href === '/newsletter')).toBe(true)
   })
 
   it('shows the News link for SuperAdmins', () => {
     const links = getVisibleNavLinks(true)
-    expect(links.some(l => l.href.startsWith('/news'))).toBe(true)
+    expect(links.some(l => l.label === 'News')).toBe(true)
   })
 })

--- a/lib/nav-links.test.ts
+++ b/lib/nav-links.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { getVisibleNavLinks } from './nav-links'
+
+describe('getVisibleNavLinks', () => {
+  it('hides the News link for non-SuperAdmins', () => {
+    const links = getVisibleNavLinks(false)
+    expect(links.some(l => l.href.startsWith('/news'))).toBe(false)
+    expect(links.some(l => l.href === '/newsletter')).toBe(true)
+  })
+
+  it('shows the News link for SuperAdmins', () => {
+    const links = getVisibleNavLinks(true)
+    expect(links.some(l => l.href.startsWith('/news'))).toBe(true)
+  })
+})

--- a/lib/nav-links.ts
+++ b/lib/nav-links.ts
@@ -1,0 +1,17 @@
+export const NAV_LINKS = [
+  { label: 'Home', href: '/' },
+  { label: 'Newsletter', href: '/newsletter' },
+  { label: 'Blog', href: '/articles' },
+  { label: 'News', href: '/news?unseen=true', superAdminOnly: true },
+  { label: 'About', href: '/about' },
+] as const
+
+export function getVisibleNavLinks(isSuperAdmin: boolean) {
+  return NAV_LINKS.filter((link) => {
+    const isSuperAdminLink = 'superAdminOnly' in link && link.superAdminOnly
+    if (isSuperAdminLink && !isSuperAdmin) {
+      return false
+    }
+    return true
+  })
+}

--- a/lib/require-super-admin.test.ts
+++ b/lib/require-super-admin.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/auth', () => ({ auth: vi.fn() }))
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn((url: string) => { throw new Error('REDIRECT:' + url) }),
+}))
+
+import { requireSuperAdmin } from './require-super-admin'
+import { auth } from '@/lib/auth'
+
+const mockAuth = vi.mocked(auth)
+
+describe('requireSuperAdmin', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('redirects logged-out users to sign-in with callbackUrl', async () => {
+    mockAuth.mockResolvedValue(null as never)
+    await expect(requireSuperAdmin('/news')).rejects.toThrow(
+      'REDIRECT:/api/auth/signin?callbackUrl=%2Fnews'
+    )
+  })
+
+  it('redirects logged-in non-admins to home', async () => {
+    mockAuth.mockResolvedValue({ user: { isSuperAdmin: false } } as never)
+    await expect(requireSuperAdmin('/news')).rejects.toThrow('REDIRECT:/')
+  })
+
+  it('returns for SuperAdmin', async () => {
+    mockAuth.mockResolvedValue({ user: { isSuperAdmin: true } } as never)
+    await expect(requireSuperAdmin('/news')).resolves.toBeUndefined()
+  })
+})

--- a/lib/require-super-admin.ts
+++ b/lib/require-super-admin.ts
@@ -1,0 +1,17 @@
+import { redirect } from 'next/navigation'
+import { auth } from '@/lib/auth'
+
+/**
+ * Server guard for SuperAdmin-only pages.
+ * Logged-out → sign-in (returns to callbackPath after auth).
+ * Logged-in but not SuperAdmin → home.
+ */
+export async function requireSuperAdmin(callbackPath: string): Promise<void> {
+  const session = await auth()
+  if (!session) {
+    redirect(`/api/auth/signin?callbackUrl=${encodeURIComponent(callbackPath)}`)
+  }
+  if (!session.user?.isSuperAdmin) {
+    redirect('/')
+  }
+}

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { NextRequest } from 'next/server'
+import { middleware } from './middleware'
+
+function reqFor(path: string, withToken = false) {
+  const req = new NextRequest(`http://localhost${path}`)
+  if (withToken) req.cookies.set('authjs.session-token', 'x')
+  return req
+}
+
+describe('middleware — logged-out news gating', () => {
+  it('redirects logged-out users away from /news', () => {
+    const res = middleware(reqFor('/news'))
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toContain('/api/auth/signin')
+  })
+
+  it('redirects logged-out users away from /read-all-news', () => {
+    const res = middleware(reqFor('/read-all-news'))
+    expect(res.headers.get('location')).toContain('/api/auth/signin')
+  })
+
+  it('lets logged-in users through to /news', () => {
+    const res = middleware(reqFor('/news', true))
+    expect(res.headers.get('location')).toBeNull()
+  })
+})

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { NextRequest } from 'next/server'
 import { middleware } from './middleware'
 
-function reqFor(path: string, withToken = false) {
+function reqFor(path: string, withToken: 'none' | 'authjs' | 'secure' = 'none') {
   const req = new NextRequest(`http://localhost${path}`)
-  if (withToken) req.cookies.set('authjs.session-token', 'x')
+  if (withToken === 'authjs') req.cookies.set('authjs.session-token', 'x')
+  if (withToken === 'secure') req.cookies.set('__Secure-authjs.session-token', 'x')
   return req
 }
 
@@ -13,15 +14,22 @@ describe('middleware — logged-out news gating', () => {
     const res = middleware(reqFor('/news'))
     expect(res.status).toBe(307)
     expect(res.headers.get('location')).toContain('/api/auth/signin')
+    expect(res.headers.get('location')).toContain('callbackUrl=%2Fnews')
   })
 
   it('redirects logged-out users away from /read-all-news', () => {
     const res = middleware(reqFor('/read-all-news'))
     expect(res.headers.get('location')).toContain('/api/auth/signin')
+    expect(res.headers.get('location')).toContain('callbackUrl=%2Fread-all-news')
   })
 
-  it('lets logged-in users through to /news', () => {
-    const res = middleware(reqFor('/news', true))
+  it('lets logged-in users through to /news (authjs.session-token)', () => {
+    const res = middleware(reqFor('/news', 'authjs'))
+    expect(res.headers.get('location')).toBeNull()
+  })
+
+  it('lets logged-in users through to /news (__Secure-authjs.session-token)', () => {
+    const res = middleware(reqFor('/news', 'secure'))
     expect(res.headers.get('location')).toBeNull()
   })
 })

--- a/middleware.ts
+++ b/middleware.ts
@@ -13,9 +13,16 @@ export function middleware(req: NextRequest) {
   const sessionToken = req.cookies.get('authjs.session-token') ||
                        req.cookies.get('__Secure-authjs.session-token')
 
-  // Protect /bookmarks page - redirect to home if no session
-  if (pathname.startsWith("/bookmarks") && !sessionToken) {
-    return NextResponse.redirect(new URL("/", req.url))
+  // Logged-out gating: bookmarks + SuperAdmin-only news routes
+  const needsSession =
+    pathname.startsWith('/bookmarks') ||
+    pathname.startsWith('/news') ||
+    pathname.startsWith('/read-all-news')
+  if (needsSession && !sessionToken) {
+    const target = pathname.startsWith('/bookmarks')
+      ? new URL('/', req.url)
+      : new URL(`/api/auth/signin?callbackUrl=${encodeURIComponent(pathname)}`, req.url)
+    return NextResponse.redirect(target)
   }
 
   // Continue the request with the new headers

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,13 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [tsconfigPaths(), react()],
+  resolve: {
+    alias: {
+      // Allow Node built-ins (fs, path) to resolve in jsdom test environment
+      fs: 'node:fs',
+      path: 'node:path',
+    },
+  },
   test: {
     environment: 'jsdom',
     setupFiles: './vitest.setup.ts',


### PR DESCRIPTION
## Summary

Make the **News** section SuperAdmin-only. Normal/logged-out users keep newsletters, blog, and other options; only a logged-in SuperAdmin (email-gated `session.user.isSuperAdmin`) sees News.

## What's gated

- **Pages:** `/news`, `/read-all-news`, and `/news/[slug]` — via a shared `requireSuperAdmin()` server guard (logged-out → sign-in with `callbackUrl`; logged-in non-admin → `/`).
- **Nav:** the "News" link is hidden for non-SuperAdmins (pure `getVisibleNavLinks` helper).
- **Middleware:** logged-out visitors to news routes redirected to sign-in.
- **APIs / actions (per-endpoint guards):**
  - `/api/content`: `contentType=news` → 403; default `contentType=all` downgraded to `article` for non-admins (closes the `all` bypass).
  - `getFilteredContent` server action: same news-403 + `all`→`article` downgrade.
  - `/api/articles/[slug]`: news excluded from `generateStaticParams` → news slugs 404.
  - `/api/trends/feed`: news filtered out of the public homepage feed.
- **Sitemap:** news URLs and the `/news` entry removed.

## Tests

Full suite green (141/141). New tests cover the guard, the API 403/downgrade behavior, the nav helper, middleware (callbackUrl encoding + both cookie names), header link visibility, slug-page guard ordering, sitemap exclusion, and the four per-endpoint fixes.

## ⚠️ KNOWN GAP — tracked follow-up (consciously accepted)

`lib/articles.ts` carries `'use server'`, so **every export is a public Server Action endpoint**. `getContentItemBySlug` is imported by a client component (`components/share-ai-button.tsx`), so a stable callable action ID is emitted. **A logged-out/normal user can invoke that action with a news slug and receive the full news item** — bypassing all route/page/middleware guards above.

This PR closes every *route-level* surface but does **not** close this RPC path. Fixing it requires either a SuperAdmin/news check inside the data layer (`getContentItemBySlug` / `getContentPageData`) or removing the `'use server'` exposure and routing client fetches through gated endpoints. Deferred by decision; **news is not fully contained until this is addressed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
