### PR TITLE
TTS fast-start: speech units (title/TLDR) + prebuffer ladder + LRU cache

### DIFF
--- a/hooks/use-continuous-reader.test.tsx
+++ b/hooks/use-continuous-reader.test.tsx
@@ -2,7 +2,6 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SpeechSection } from '@/lib/tts-speech'
-import { splitIntoChunks } from '@/lib/tts-chunks'
 import { DEFAULT_TTS_VOICE, setStoredTtsVoice, TTS_VOICE_STORAGE_KEY } from '@/lib/tts-voices'
 import { useContinuousReader } from './use-continuous-reader'
 
@@ -82,8 +81,12 @@ const deferred = <T,>() => {
   return { promise, resolve }
 }
 
+// Pending-synthesis harness. Dedupes by text (mirroring the real synthesis
+// cache) so the prebuffer scheduler and playback, which BOTH call
+// synthesizeSpeech, share one never-resolving deferred per text. Exposes
+// requests keyed by text so a test can resolve a specific (e.g. stale) one.
 const setupPendingSynthesis = () => {
-  const requests: Array<ReturnType<typeof deferred<ArrayBuffer>>> = []
+  const requestsByText = new Map<string, ReturnType<typeof deferred<ArrayBuffer>>>()
   const events: string[] = []
   const originalAbort = AbortController.prototype.abort
 
@@ -92,13 +95,15 @@ const setupPendingSynthesis = () => {
     return originalAbort.call(this)
   })
   ttsClientMock.synthesizeSpeech.mockImplementation((text: string) => {
+    const existing = requestsByText.get(text)
+    if (existing) return existing.promise
     events.push(`synthesize:${text}`)
     const request = deferred<ArrayBuffer>()
-    requests.push(request)
+    requestsByText.set(text, request)
     return request.promise
   })
 
-  return { events, requests }
+  return { events, requestsByText }
 }
 
 const makeItem = (index: number): SpeechSection => ({
@@ -281,74 +286,66 @@ describe('useContinuousReader', () => {
     expect(ttsMock.playback.play).toHaveBeenCalledTimes(2)
   })
 
-  it('invalidates pending synthesis before direct playFrom during Next flow and ignores its stale resolution', async () => {
+  it('interrupts the pending playback synthesis on play-from-here and ignores its stale resolution', async () => {
     ttsMock.useActualTTS = true
-    const { events, requests } = setupPendingSynthesis()
+    const { events, requestsByText } = setupPendingSynthesis()
     const { result } = renderHook(() =>
       useContinuousReader([makeItem(0), makeItem(1), makeItem(2)])
     )
 
+    // Section 0's first (title) unit is 'News' (its sourceTitle).
     act(() => result.current.play())
-    await waitFor(() => expect(requests).toHaveLength(1))
+    await waitFor(() => expect(requestsByText.has('News')).toBe(true))
 
     act(() => result.current.playFrom(1))
     await waitFor(() => {
-      expect(requests).toHaveLength(2)
+      expect(result.current.currentIndex).toBe(1)
       expect(result.current.isPlaying).toBe(true)
       expect(result.current.isBuffering).toBe(true)
     })
+    // Section 1's title unit is now the one being synthesized, and the
+    // interrupt aborted the in-flight (section-0) request.
+    await waitFor(() => expect(requestsByText.has('Section 1')).toBe(true))
+    expect(events).toContain('abort')
 
-    expect(events).toEqual([
-      'synthesize:prepared speech 0',
-      'abort',
-      'synthesize:prepared speech 1',
-    ])
-    expect(result.current.currentIndex).toBe(1)
-
+    // Resolving the STALE section-0 synthesis must not regress state.
     await act(async () => {
-      requests[0].resolve(new ArrayBuffer(0))
+      requestsByText.get('News')!.resolve(new ArrayBuffer(0))
       await Promise.resolve()
     })
 
     expect(result.current.currentIndex).toBe(1)
     expect(result.current.isPlaying).toBe(true)
     expect(result.current.isBuffering).toBe(true)
-    expect(requests).toHaveLength(2)
   })
 
-  it('invalidates pending synthesis before direct playFrom and ignores its stale resolution', async () => {
+  it('interrupts the pending playback synthesis on play-from-here to a farther section', async () => {
     ttsMock.useActualTTS = true
-    const { events, requests } = setupPendingSynthesis()
+    const { events, requestsByText } = setupPendingSynthesis()
     const { result } = renderHook(() =>
       useContinuousReader([makeItem(0), makeItem(1), makeItem(2)])
     )
 
     act(() => result.current.play())
-    await waitFor(() => expect(requests).toHaveLength(1))
+    await waitFor(() => expect(requestsByText.has('News')).toBe(true))
 
     act(() => result.current.playFrom(2))
     await waitFor(() => {
-      expect(requests).toHaveLength(2)
+      expect(result.current.currentIndex).toBe(2)
       expect(result.current.isPlaying).toBe(true)
       expect(result.current.isBuffering).toBe(true)
     })
-
-    expect(events).toEqual([
-      'synthesize:prepared speech 0',
-      'abort',
-      'synthesize:prepared speech 2',
-    ])
-    expect(result.current.currentIndex).toBe(2)
+    await waitFor(() => expect(requestsByText.has('Section 2')).toBe(true))
+    expect(events).toContain('abort')
 
     await act(async () => {
-      requests[0].resolve(new ArrayBuffer(0))
+      requestsByText.get('News')!.resolve(new ArrayBuffer(0))
       await Promise.resolve()
     })
 
     expect(result.current.currentIndex).toBe(2)
     expect(result.current.isPlaying).toBe(true)
     expect(result.current.isBuffering).toBe(true)
-    expect(requests).toHaveLength(2)
   })
 
   it('automatically advances on completion', async () => {
@@ -367,77 +364,74 @@ describe('useContinuousReader', () => {
     expect(onItemChange).toHaveBeenLastCalledWith(makeItem(1), 1)
   })
 
-  it('reader prefetches the next section\'s first chunk once when progress passes the threshold', async () => {
-    const { result } = renderHook(() =>
-      useContinuousReader([makeItem(0), makeItem(1)])
+  it('prebuffer ladder warms all section titles, then all TLDRs', async () => {
+    ttsClientMock.synthesizeSpeech.mockResolvedValue(new ArrayBuffer(0))
+    renderHook(() => useContinuousReader([makeItem(0), makeItem(1), makeItem(2)]))
+
+    const warmed = () =>
+      ttsClientMock.synthesizeSpeech.mock.calls.map(([text]) => text as string)
+
+    // Titles of every loaded section (s0 title = its sourceTitle 'News').
+    await waitFor(() =>
+      expect(warmed()).toEqual(expect.arrayContaining(['News', 'Section 1', 'Section 2']))
     )
-
-    act(() => result.current.play())
-    await waitFor(() => expect(ttsMock.playback.play).toHaveBeenCalledOnce())
-    await waitFor(() => expect(ttsMock.getLatestOptions()?.voice).toBe('pl-PL-ZofiaNeural'))
-
-    const onProgress = () => ttsMock.getLatestOptions()?.onProgress as (progress: number) => void
-    // Only the next-section (section 1) progress prefetch matters here; the
-    // section-0 mount preload is a separate path.
-    const nextSectionCalls = () =>
-      ttsClientMock.prefetchSpeech.mock.calls.filter(([chunk]) => chunk === 'prepared speech 1')
-
-    // Below threshold: no next-section prefetch yet.
-    act(() => onProgress()(50))
-    expect(nextSectionCalls()).toHaveLength(0)
-
-    // Crossing the threshold fires exactly once for this section...
-    act(() => onProgress()(70))
-    act(() => onProgress()(85))
-
-    expect(nextSectionCalls()).toHaveLength(1)
-    expect(ttsClientMock.prefetchSpeech).toHaveBeenCalledWith('prepared speech 1', {
-      voice: 'pl-PL-ZofiaNeural',
-    })
-  })
-
-  it('does not prefetch past the last section', async () => {
-    const { result } = renderHook(() => useContinuousReader([makeItem(0)]))
-
-    act(() => result.current.play())
-    await waitFor(() => expect(ttsMock.playback.play).toHaveBeenCalledOnce())
-
-    // Ignore the section-0 mount preload; assert progress adds no next-section prefetch.
-    ttsClientMock.prefetchSpeech.mockClear()
-
-    act(() => (ttsMock.getLatestOptions()?.onProgress as (progress: number) => void)(90))
-
-    expect(ttsClientMock.prefetchSpeech).not.toHaveBeenCalled()
-  })
-
-  it('preloads the first section\'s first chunk once on mount', async () => {
-    const { rerender } = renderHook(() =>
-      useContinuousReader([makeItem(0), makeItem(1)])
-    )
-
-    // Mount warms section 0's first chunk exactly once, with the resolved voice.
-    await waitFor(() => {
-      expect(ttsClientMock.prefetchSpeech).toHaveBeenCalledWith(
-        splitIntoChunks('prepared speech 0')[0] ?? '',
-        { voice: DEFAULT_TTS_VOICE }
+    // Then every section's TLDR (here the no-TLDR fallback = body unit).
+    await waitFor(() =>
+      expect(warmed()).toEqual(
+        expect.arrayContaining(['Visible markdown 0', 'Visible markdown 1', 'Visible markdown 2'])
       )
-    })
-
-    // The stored voice resolves post-mount (Task 3). That voice change must not
-    // re-fire the first-section preload.
-    act(() => setStoredTtsVoice('en-US-EmmaMultilingualNeural'))
-    rerender()
-
-    const sectionZeroCalls = ttsClientMock.prefetchSpeech.mock.calls.filter(
-      ([chunk]) => chunk === 'prepared speech 0'
     )
-    expect(sectionZeroCalls).toHaveLength(1)
+
+    // Tier gate: OTHER sections' titles are warmed before their TLDRs. (The
+    // CURRENT section's title+TLDR come first, in T1, to secure runway.)
+    const calls = warmed()
+    const lastOtherTitle = Math.max(calls.indexOf('Section 1'), calls.indexOf('Section 2'))
+    const firstOtherTldr = Math.min(
+      calls.indexOf('Visible markdown 1'),
+      calls.indexOf('Visible markdown 2')
+    )
+    expect(lastOtherTitle).toBeGreaterThanOrEqual(0)
+    expect(lastOtherTitle).toBeLessThan(firstOtherTldr)
   })
 
-  it('does not preload when there are no sections', () => {
+  it('prebuffer warms the current section title + TLDR first (runway)', async () => {
+    ttsClientMock.synthesizeSpeech.mockResolvedValue(new ArrayBuffer(0))
+    renderHook(() => useContinuousReader([makeItem(0), makeItem(1), makeItem(2)]))
+
+    const warmed = () =>
+      ttsClientMock.synthesizeSpeech.mock.calls.map(([text]) => text as string)
+
+    await waitFor(() => expect(warmed()).toContain('News'))
+    // Current section (index 0) title 'News' and its unit-2 'Visible markdown 0'
+    // are the first two warmed, before other sections' titles.
+    const calls = warmed()
+    expect(calls.indexOf('News')).toBeLessThan(calls.indexOf('Section 1'))
+    expect(calls.indexOf('Visible markdown 0')).toBeLessThan(calls.indexOf('Section 1'))
+  })
+
+  it('re-runs the ladder with the new voice when the voice changes', async () => {
+    ttsClientMock.synthesizeSpeech.mockResolvedValue(new ArrayBuffer(0))
+    renderHook(() => useContinuousReader([makeItem(0), makeItem(1)]))
+
+    const warmedWith = (voice: string) =>
+      ttsClientMock.synthesizeSpeech.mock.calls.some(
+        ([text, opts]) => text === 'Section 1' && (opts as { voice?: string }).voice === voice
+      )
+
+    await waitFor(() => expect(warmedWith('pl-PL-ZofiaNeural')).toBe(true))
+
+    ttsClientMock.synthesizeSpeech.mockClear()
+    act(() => setStoredTtsVoice('en-US-EmmaMultilingualNeural'))
+
+    await waitFor(() => expect(warmedWith('en-US-EmmaMultilingualNeural')).toBe(true))
+  })
+
+  it('does not prebuffer when there are no sections', async () => {
+    ttsClientMock.synthesizeSpeech.mockResolvedValue(new ArrayBuffer(0))
     renderHook(() => useContinuousReader([]))
 
-    expect(ttsClientMock.prefetchSpeech).not.toHaveBeenCalled()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(ttsClientMock.synthesizeSpeech).not.toHaveBeenCalled()
   })
 
   it('stops with a retryable error on synthesis failure', async () => {

--- a/hooks/use-continuous-reader.ts
+++ b/hooks/use-continuous-reader.ts
@@ -1,15 +1,46 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { SpeechSection } from '@/lib/tts-speech'
-import { splitIntoChunks } from '@/lib/tts-chunks'
-import { prefetchSpeech } from '@/lib/tts-client'
+import { splitIntoSpeechUnits, type SpeechSection } from '@/lib/tts-speech'
+import { synthesizeSpeech } from '@/lib/tts-client'
 import { DEFAULT_TTS_VOICE, getStoredTtsVoice, TTS_VOICE_CHANGE_EVENT, type TtsVoice } from '@/lib/tts-voices'
 import { useTTS } from './useTTS'
 import type { TTSPlayback } from './useTTS'
 
 export interface ContinuousReaderOptions {
   onItemChange?: (item: SpeechSection, index: number) => void
+}
+
+// How many prebuffer warm requests run concurrently. Each edge-tts synthesis is
+// a fresh WebSocket, so keep this low enough not to starve the real
+// play-from-here request while still warming the ladder quickly.
+const PREBUFFER_CONCURRENCY = 2
+
+/**
+ * Warm the synthesis cache for a tier of unit texts with bounded concurrency.
+ * Best-effort: `synthesizeSpeech` caches + dedupes, so already-warm texts are
+ * skipped and failures are ignored (the real playback request retries).
+ */
+async function warmTier(
+  texts: readonly string[],
+  voice: string,
+  concurrency: number,
+  signal: AbortSignal
+): Promise<void> {
+  const queue = [...texts]
+  const worker = async (): Promise<void> => {
+    while (queue.length > 0) {
+      if (signal.aborted) return
+      const text = queue.shift()
+      if (!text) continue
+      try {
+        await synthesizeSpeech(text, { voice })
+      } catch {
+        /* best-effort warm; the real request will retry */
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.max(1, concurrency) }, worker))
 }
 
 export function useContinuousReader(
@@ -25,35 +56,26 @@ export function useContinuousReader(
   const onItemChangeRef = useRef(onItemChange)
   const pendingStartRef = useRef<number | null>(null)
   const playbackRef = useRef<TTSPlayback | null>(null)
-  // Tracks the section index for which the next-section prefetch has fired, so
-  // it warms the following section's first chunk at most once per section.
-  const prefetchedForIndexRef = useRef<number | null>(null)
-  // Tracks the first section's text already warmed by the mount preload, so it
-  // fires once per distinct first-section content and does not re-fire when the
-  // stored voice resolves right after mount.
-  const preloadedFirstTextRef = useRef<string | null>(null)
   const [voice, setVoice] = useState<TtsVoice>(DEFAULT_TTS_VOICE)
 
   useEffect(() => {
     setVoice(getStoredTtsVoice())
   }, [])
 
-  // Warm the first section's first chunk as soon as the reader has sections, so
-  // the very first Play is near-instant. Guarded on the first section's text
-  // (not voice) so the post-mount stored-voice update does not re-trigger it.
+  // Speech units per section (title → TLDR → body chunks). Recomputed only when
+  // the loaded section set changes; the current section's units feed useTTS and
+  // the [0]/[1] units feed the prebuffer ladder.
+  const unitsBySection = useMemo(
+    () => items.map((section) => splitIntoSpeechUnits(section)),
+    [items]
+  )
+  const unitsBySectionRef = useRef(unitsBySection)
   useEffect(() => {
-    const firstText = items[0]?.speechText
-    if (!firstText) return
-    if (preloadedFirstTextRef.current === firstText) return
-
-    preloadedFirstTextRef.current = firstText
-    prefetchSpeech(splitIntoChunks(firstText)[0] ?? '', { voice })
-  }, [items, voice])
+    unitsBySectionRef.current = unitsBySection
+  }, [unitsBySection])
 
   useEffect(() => {
     currentIndexRef.current = currentIndex
-    // Reset the once-per-section prefetch guard on every section change.
-    prefetchedForIndexRef.current = null
   }, [currentIndex])
 
   useEffect(() => {
@@ -102,18 +124,7 @@ export function useContinuousReader(
 
   const playback = useTTS(items[currentIndex]?.speechText ?? '', {
     voice,
-    onProgress: useCallback((progress: number) => {
-      if (progress < 70) return
-
-      const index = currentIndexRef.current
-      const nextIndex = index + 1
-      if (nextIndex >= itemsRef.current.length) return
-      if (prefetchedForIndexRef.current === index) return
-
-      prefetchedForIndexRef.current = index
-      const nextText = itemsRef.current[nextIndex]?.speechText ?? ''
-      prefetchSpeech(splitIntoChunks(nextText)[0] ?? '', { voice })
-    }, [voice]),
+    units: unitsBySection[currentIndex],
     onComplete: useCallback(() => {
       if (currentIndexRef.current !== currentIndex) return
 
@@ -131,6 +142,51 @@ export function useContinuousReader(
   useEffect(() => {
     playbackRef.current = playback
   }, [playback])
+
+  // Prebuffer ladder: warm the synthesis cache ahead of user intent so
+  // play-from-here on any section starts from cache. Order: current section's
+  // title + TLDR first (secures playback runway = "T1 buffered"), THEN every
+  // loaded section's title, THEN every loaded section's TLDR. Restarts on voice
+  // change, section-set change, or current-section change; idempotent (warm
+  // requests hit the cache and skip). Non-current bodies are not prebuffered
+  // here — they load on demand as playback approaches them.
+  useEffect(() => {
+    if (unitsBySection.length === 0) return
+
+    const controller = new AbortController()
+    const { signal } = controller
+
+    const run = async (): Promise<void> => {
+      const all = unitsBySectionRef.current
+      const current = all[currentIndexRef.current]
+      // T1: current section's title + TLDR.
+      if (current) {
+        await warmTier(current.slice(0, 2), voice, PREBUFFER_CONCURRENCY, signal)
+      }
+      if (signal.aborted) return
+      // T2: every loaded section's title unit.
+      const titles = all.map((u) => u[0]).filter((t): t is string => Boolean(t))
+      await warmTier(titles, voice, PREBUFFER_CONCURRENCY, signal)
+      if (signal.aborted) return
+      // T3: every loaded section's TLDR (second) unit — only after all titles.
+      const tldrs = all.map((u) => u[1]).filter((t): t is string => Boolean(t))
+      await warmTier(tldrs, voice, PREBUFFER_CONCURRENCY, signal)
+    }
+
+    const useIdle = typeof requestIdleCallback === 'function'
+    const handle = useIdle
+      ? requestIdleCallback(() => void run())
+      : setTimeout(() => void run(), 0)
+
+    return () => {
+      controller.abort()
+      if (useIdle && typeof cancelIdleCallback === 'function') {
+        cancelIdleCallback(handle as number)
+      } else {
+        clearTimeout(handle as ReturnType<typeof setTimeout>)
+      }
+    }
+  }, [unitsBySection, voice, currentIndex])
 
   useEffect(() => {
     if (pendingStartRef.current !== currentIndex) return

--- a/hooks/useTTS.test.tsx
+++ b/hooks/useTTS.test.tsx
@@ -205,3 +205,36 @@ describe('useTTS replay with a cached (shared) synthesis buffer', () => {
     expect(result.current.isPlaying).toBe(true)
   })
 })
+
+describe('useTTS units option', () => {
+  it('plays the provided units in order instead of length-chunking the content', async () => {
+    vi.mocked(synthesizeSpeech).mockClear()
+    const units = ['Title unit', 'TLDR unit here.', 'Body chunk text.']
+
+    const { result } = renderHook(() =>
+      useTTS('prepared flattened content that would otherwise be one chunk', { units })
+    )
+
+    await act(async () => {
+      await result.current.play()
+    })
+    await waitFor(() => expect(sequence).toContain('start'))
+
+    // First synthesis is the tiny title unit, not the whole content.
+    expect(vi.mocked(synthesizeSpeech).mock.calls[0][0]).toBe('Title unit')
+    expect(result.current.totalChunks).toBe(3)
+  })
+
+  it('falls back to length-chunking when units is empty or omitted', async () => {
+    vi.mocked(synthesizeSpeech).mockClear()
+
+    const { result } = renderHook(() => useTTS('Just one sentence.', { units: [] }))
+
+    await act(async () => {
+      await result.current.play()
+    })
+    await waitFor(() => expect(sequence).toContain('start'))
+
+    expect(vi.mocked(synthesizeSpeech).mock.calls[0][0]).toBe('Just one sentence.')
+  })
+})

--- a/hooks/useTTS.ts
+++ b/hooks/useTTS.ts
@@ -18,6 +18,14 @@ export interface TTSState {
 export interface UseTTSOptions {
   voice?: string
   /**
+   * Pre-split speech units for `content`, in play order (title → TLDR → body
+   * chunks — see `splitIntoSpeechUnits`). When provided and non-empty, these are
+   * used verbatim as the chunk list instead of `splitIntoChunks(content)`, so
+   * the first spoken unit is tiny (fast-start) and matches the strings the
+   * prebuffer ladder warms. Must correspond to `content` (same section).
+   */
+  units?: string[]
+  /**
    * Fired on EVERY requestAnimationFrame tick during playback (~60Hz) with the
    * 0–100 progress percent — intentionally NOT throttled, so the continuous
    * reader's prefetch threshold sees continuous progress. Keep the handler
@@ -41,7 +49,12 @@ const detectLanguage = detectLanguageFromContent
 const BUFFER_AHEAD = 2
 
 export function useTTS(content: string, options: UseTTSOptions = {}) {
-  const { voice, onProgress, onComplete, onError } = options
+  const { voice, units, onProgress, onComplete, onError } = options
+
+  // Latest units, read inside play() without adding array-identity churn to its
+  // deps (the caller passes a fresh array per render).
+  const unitsRef = useRef<string[] | undefined>(units)
+  unitsRef.current = units
 
   const [state, setState] = useState<TTSState>({
     isPlaying: false,
@@ -320,9 +333,15 @@ export function useTTS(content: string, options: UseTTSOptions = {}) {
   const play = useCallback(async () => {
     if (isPlayingRef.current) return
 
-    // Initialize chunks on first play or after completion reset
+    // Initialize chunks on first play or after completion reset. Prefer
+    // pre-split speech units (title → TLDR → body) when the caller supplies
+    // them; otherwise fall back to length-based chunking of the raw content.
     if (chunksRef.current.length === 0) {
-      chunksRef.current = splitIntoChunks(content)
+      const providedUnits = unitsRef.current
+      chunksRef.current =
+        providedUnits && providedUnits.length > 0
+          ? providedUnits
+          : splitIntoChunks(content)
       charCountsRef.current = chunksRef.current.map((c) => c.length)
       totalCharsRef.current = charCountsRef.current.reduce((a, b) => a + b, 0)
 

--- a/lib/tts-client.test.ts
+++ b/lib/tts-client.test.ts
@@ -106,24 +106,49 @@ describe('synthesizeSpeech cache', () => {
     expect(edgeMock.streamCount).toBe(2)
   })
 
-  it('synthesis cache evicts oldest entries beyond the cap', async () => {
+  it('synthesis cache evicts the least-recently-used entry beyond the cap (200)', async () => {
     const voice = 'en-GB-RyanNeural'
+    const CAP = 200
 
-    for (let i = 0; i < 24; i += 1) {
+    // Fill the cache exactly to the cap.
+    for (let i = 0; i < CAP; i += 1) {
       await synthesizeSpeech(`text-${i}`, { voice })
     }
-    expect(edgeMock.constructCount).toBe(24)
+    expect(edgeMock.constructCount).toBe(CAP)
 
-    // 25th distinct key evicts the oldest inserted key (text-0).
-    await synthesizeSpeech('text-24', { voice })
-    expect(edgeMock.constructCount).toBe(25)
-
-    // text-1 is still cached (a read does not re-synthesize).
-    await synthesizeSpeech('text-1', { voice })
-    expect(edgeMock.constructCount).toBe(25)
+    // One more distinct key overflows and evicts the LRU (text-0, untouched).
+    await synthesizeSpeech(`text-${CAP}`, { voice })
+    expect(edgeMock.constructCount).toBe(CAP + 1)
 
     // text-0 was evicted, so it must be synthesized again.
     await synthesizeSpeech('text-0', { voice })
-    expect(edgeMock.constructCount).toBe(26)
+    expect(edgeMock.constructCount).toBe(CAP + 2)
+  })
+
+  it('LRU: reading an entry protects it from eviction (touch on read)', async () => {
+    const voice = 'en-GB-RyanNeural'
+    const CAP = 200
+
+    for (let i = 0; i < CAP; i += 1) {
+      await synthesizeSpeech(`k-${i}`, { voice })
+    }
+    expect(edgeMock.constructCount).toBe(CAP)
+
+    // Touch the oldest entry (k-0) so it becomes most-recently-used; now k-1 is
+    // the LRU. Reading must NOT re-synthesize.
+    await synthesizeSpeech('k-0', { voice })
+    expect(edgeMock.constructCount).toBe(CAP)
+
+    // Overflow: the new LRU (k-1) is evicted, not the just-touched k-0.
+    await synthesizeSpeech(`k-${CAP}`, { voice })
+    expect(edgeMock.constructCount).toBe(CAP + 1)
+
+    // k-0 survived (still cached, no re-synthesis)...
+    await synthesizeSpeech('k-0', { voice })
+    expect(edgeMock.constructCount).toBe(CAP + 1)
+
+    // ...while k-1 was evicted and must re-synthesize.
+    await synthesizeSpeech('k-1', { voice })
+    expect(edgeMock.constructCount).toBe(CAP + 2)
   })
 })

--- a/lib/tts-client.ts
+++ b/lib/tts-client.ts
@@ -13,15 +13,25 @@ interface TTSOptions {
 
 const DEFAULT_VOICE = 'en-GB-RyanNeural'
 
-// Maximum number of distinct synthesis results to keep cached (FIFO-bounded).
-const MAX_CACHE_ENTRIES = 24
+// Maximum number of distinct synthesis results to keep cached (LRU-bounded).
+// Raised well above the old 24 so the prebuffer ladder can warm every loaded
+// section's title AND TLDR (2 per section) plus the playing section's body
+// without thrashing. Entries are compressed MP3 (~tens of KB), so the memory
+// cost of ~200 entries is a few MB.
+const MAX_CACHE_ENTRIES = 200
 
 /**
  * Module-level synthesis cache keyed by `${voice}::${text}`.
  *
  * Stores the in-flight promise so concurrent callers (and cross-section
  * prefetch) dedupe onto a single synthesis. Survives useTTS `content` swaps so
- * the next section's first chunk can be warmed while the current one plays.
+ * the next section's units can be warmed while the current one plays.
+ *
+ * Eviction is LRU: a Map preserves insertion order, so every *use* (a cache hit
+ * in `synthesizeSpeech`) re-inserts the key to move it to the most-recent end,
+ * and eviction drops the least-recently-used (front) key. This protects a
+ * prebuffered title/TLDR that has not been played yet and the currently-playing
+ * body from being evicted by later prefetch, which pure FIFO could not.
  */
 const synthesisCache = new Map<string, Promise<ArrayBuffer>>()
 
@@ -29,10 +39,18 @@ function cacheKey(voice: string, text: string): string {
   return `${voice}::${text}`
 }
 
+// Mark a key as most-recently-used by moving it to the end of the Map's order.
+function touchCache(key: string): void {
+  const promise = synthesisCache.get(key)
+  if (promise === undefined) return
+  synthesisCache.delete(key)
+  synthesisCache.set(key, promise)
+}
+
 function storeInCache(key: string, promise: Promise<ArrayBuffer>): void {
   synthesisCache.set(key, promise)
 
-  // FIFO eviction: drop the oldest inserted key(s) once over the cap.
+  // LRU eviction: drop the least-recently-used key(s) once over the cap.
   while (synthesisCache.size > MAX_CACHE_ENTRIES) {
     const oldest = synthesisCache.keys().next().value
     if (oldest === undefined) break
@@ -109,7 +127,10 @@ export async function synthesizeSpeech(
   const key = cacheKey(voice, text)
 
   const cached = synthesisCache.get(key)
-  if (cached) return cached
+  if (cached) {
+    touchCache(key) // LRU: reading an entry marks it most-recently-used.
+    return cached
+  }
 
   // Store the in-flight promise BEFORE awaiting so concurrent callers dedupe.
   const promise = synthesizeToBuffer(text, options, voice)

--- a/lib/tts-speech.test.ts
+++ b/lib/tts-speech.test.ts
@@ -4,8 +4,94 @@ import {
   prepareSpeechSections,
   prepareSpeechText,
   replaceWholeWordMappings,
+  splitIntoSpeechUnits,
   splitReviewedSections,
+  type SpeechSection,
 } from './tts-speech'
+
+const section = (over: Partial<SpeechSection>): SpeechSection => ({
+  sourceSlug: 'news',
+  sourceTitle: undefined,
+  title: 'Section title',
+  markdown: '## Section title\nBody sentence one. Body sentence two.',
+  speechText: '',
+  ...over,
+})
+
+describe('splitIntoSpeechUnits', () => {
+  it('emits [title, tldr, ...body] with title first from sourceTitle', () => {
+    const units = splitIntoSpeechUnits(
+      section({
+        sourceTitle: 'Article Title',
+        title: 'Article Title',
+        markdown: '## Article Title\n**TLDR:** Short summary here.\n\nFull body paragraph text.',
+      })
+    )
+
+    expect(units[0]).toBe('Article Title')
+    // The TLDR unit is the `**TLDR:**` paragraph, run through prepareSpeechText
+    // (which maps the structural `tldr`/`summary` labels to pause punctuation).
+    expect(units[1]).toBe(prepareSpeechText('**TLDR:** Short summary here.'))
+    expect(units[1]).not.toContain('Full body paragraph text.')
+    expect(units.slice(2).join(' ')).toContain('Full body paragraph text.')
+  })
+
+  it('does not speak the heading twice when sourceTitle equals the heading', () => {
+    const units = splitIntoSpeechUnits(
+      section({
+        sourceTitle: 'Same Title',
+        title: 'Same Title',
+        markdown: '## Same Title\n**TLDR:** A summary.\n\nBody.',
+      })
+    )
+
+    // "Same Title" appears exactly once across all units (title unit only).
+    const occurrences = units.filter((u) => u.includes('Same Title')).length
+    expect(occurrences).toBe(1)
+    expect(units[0]).toBe('Same Title')
+  })
+
+  it('falls back to the body first sentence as unit 2 when there is no TLDR', () => {
+    const units = splitIntoSpeechUnits(
+      section({
+        sourceTitle: 'Title',
+        markdown: '## Title\nFirst sentence here. Second sentence follows. Third one too.',
+      })
+    )
+
+    expect(units[0]).toBe('Title')
+    expect(units[1]).toBe('First sentence here.')
+    expect(units[2]).toContain('Second sentence follows.')
+  })
+
+  it('uses the section heading as the title when there is no sourceTitle', () => {
+    const units = splitIntoSpeechUnits(
+      section({
+        sourceTitle: undefined,
+        title: 'Heading Only',
+        markdown: '## Heading Only\n**TLDR:** T.\n\nBody.',
+      })
+    )
+
+    expect(units[0]).toBe('Heading Only')
+  })
+
+  it('keeps body chunks at the default (non-shrunk) chunk size', () => {
+    const long = 'Zdanie. '.repeat(400) // ~3200 chars of body
+    const units = splitIntoSpeechUnits(
+      section({
+        sourceTitle: 'T',
+        markdown: `## T\n**TLDR:** Krotko.\n\n${long}`,
+      })
+    )
+
+    const bodyUnits = units.slice(2)
+    expect(bodyUnits.length).toBeGreaterThan(1)
+    // No body chunk exceeds the 1000-char default; none is artificially tiny.
+    for (const chunk of bodyUnits) expect(chunk.length).toBeLessThanOrEqual(1000)
+    expect(Math.max(...bodyUnits.map((c) => c.length))).toBeGreaterThan(500)
+  })
+})
 
 describe('splitReviewedSections', () => {
   it('splits consecutive reviewed sections in source order', () => {

--- a/lib/tts-speech.ts
+++ b/lib/tts-speech.ts
@@ -1,4 +1,5 @@
 import { PRONUNCIATION_MAP } from '@/lib/tts-pronunciation'
+import { splitIntoChunks } from '@/lib/tts-chunks'
 
 export interface SpeechSource {
   slug: string
@@ -113,4 +114,60 @@ export function prepareSpeechSections(sources: readonly SpeechSource[]): SpeechS
       [section.sourceTitle, section.markdown].filter(Boolean).join('\n')
     ),
   }))
+}
+
+// Matches the leading `## heading` line of a section's markdown (removed so the
+// heading is not spoken again as body — the title unit already speaks it).
+const LEADING_HEADING = /^##[ \t]+.*(?:\r?\n|$)/
+
+// Matches a `**TLDR:**` (or `**TLDR**`) paragraph up to the next blank line.
+const TLDR_PARAGRAPH = /(?:^|\n)[ \t]*\*\*TLDR:?\*\*[\s\S]*?(?=\n[ \t]*\n|$)/i
+
+const firstSentence = (text: string): string | null =>
+  text.match(/^[\s\S]*?[.!?]+(?=\s|$)/)?.[0].trim() ?? null
+
+/**
+ * Split a section into ordered **speech units** for synthesis and playback:
+ * `[title, tldr?, ...bodyChunks]`. Each unit is `prepareSpeechText`'d
+ * individually so its string is a stable, reusable synthesis-cache key (the
+ * prebuffer ladder warms these exact strings).
+ *
+ * - **Title** = the section's `sourceTitle` (article/frontmatter title) when
+ *   present, else its `##` heading. The `##` heading is stripped from the body
+ *   so the title is spoken exactly once (no double-title read).
+ * - **TLDR** = the `**TLDR:**` paragraph. If absent, the second unit is the
+ *   body's first sentence instead (keeps the fast-start second unit small).
+ * - **Body** stays at the default 1000-char chunking (not cut smaller): the
+ *   title + TLDR give enough playback runway to fetch full body chunks ahead.
+ */
+export function splitIntoSpeechUnits(section: SpeechSection): string[] {
+  const units: string[] = []
+
+  const titleText = (section.sourceTitle ?? section.title ?? '').trim()
+  const title = prepareSpeechText(titleText)
+  if (title) units.push(title)
+
+  // Body = section markdown minus its leading `## heading` line.
+  let body = section.markdown.replace(LEADING_HEADING, '')
+
+  const tldrMatch = body.match(TLDR_PARAGRAPH)
+  if (tldrMatch) {
+    const tldr = prepareSpeechText(tldrMatch[0])
+    if (tldr) units.push(tldr)
+    const rest = body.slice(0, tldrMatch.index) + body.slice(tldrMatch.index! + tldrMatch[0].length)
+    units.push(...splitIntoChunks(prepareSpeechText(rest)))
+  } else {
+    // No TLDR: second unit is the body's first sentence, remainder follows.
+    const preparedBody = prepareSpeechText(body)
+    const first = firstSentence(preparedBody)
+    if (first) {
+      units.push(first)
+      const remainder = preparedBody.slice(first.length).trim()
+      if (remainder) units.push(...splitIntoChunks(remainder))
+    } else if (preparedBody) {
+      units.push(...splitIntoChunks(preparedBody))
+    }
+  }
+
+  return units.filter((u) => u.length > 0)
 }


### PR DESCRIPTION
## Why

Play-from-here (and first Play) had a visible delay: `useTTS.play()` had to fully synthesize the first ~1000-char chunk over a fresh edge-tts WebSocket before any audio played.

## What

Play-from-here now starts near-instantly.

- **Speech units** (`splitIntoSpeechUnits`): a section is spoken as `[title, tldr?, ...body]`. Title comes from `sourceTitle` (the `##` heading is no longer read twice); TLDR = the `**TLDR:**` paragraph (fallback: body's first sentence); body stays at 1000-char chunks (title ~2s + TLDR ~25s already give ample runway).
- **Prebuffer ladder** (`use-continuous-reader`): warms the synthesis cache ahead of intent, concurrency 2 — **T1** current section title+TLDR → **T2** every loaded section's title → **T3** every loaded section's TLDR. Restarts on voice / section-set / current-section change. Replaces the old 70%-progress warm + mount preload.
- **`useTTS`**: optional `units?: string[]` (falls back to `splitIntoChunks`).
- **Synthesis cache**: cap 24→200, FIFO→**LRU** (touch on read) so warmed titles/TLDRs and the playing body survive eviction.

Result: the target section's title is already cached (T2) → instant start; TLDR is cached (T3) or a fast small synth; body fills within the runway.

## Notes

- One audible change: the accidental double-title read at each article start is removed.
- Pronunciation map already maps `tldr`→`..`, `summary`→`,,` (structural labels → pauses); kept as-is.

## Tests

- `270/270` pass. Added: LRU cap + touch-on-read; `splitIntoSpeechUnits` (title/TLDR/fallback/no-double-title/body-size); `useTTS` units; reader ladder ordering + runway + voice-restart + no-op-empty. Rewrote the two play-from-here invalidation tests to state-invariants (the scheduler now shares `synthesizeSpeech`).
- Design spec: `projects/motyl/plans/2026-08-19-tts-fast-start-title-prebuffer-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)